### PR TITLE
Build portable terminal configuration CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,37 +5,287 @@
 [![Tests](https://github.com/zetlen/console-cowboy/actions/workflows/test.yml/badge.svg)](https://github.com/zetlen/console-cowboy/actions/workflows/test.yml)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/zetlen/console-cowboy/blob/master/LICENSE)
 
-Hop terminals like you hop linux distributions.
+**Hop terminals like you hop Linux distributions.**
+
+Console Cowboy is a CLI tool for making terminal configurations portable across different terminal emulators. Export your settings from one terminal and import them into another.
+
+## Features
+
+- **Portable Configuration Format**: Uses CTEC (Common Terminal Emulator Configuration) as an intermediate representation
+- **Multiple Terminal Support**: Import and export configurations for:
+  - iTerm2
+  - Ghostty
+  - Alacritty
+  - Kitty
+  - Wezterm
+- **Multiple Output Formats**: CTEC files can be stored as TOML (default), JSON, or YAML
+- **Incompatibility Reporting**: Clearly reports which settings cannot be converted between terminals
+- **Terminal-Specific Settings**: Preserves terminal-specific settings that don't have equivalents in other terminals
 
 ## Installation
 
-Install this tool using `pip`:
+Install using `pip`:
+
 ```bash
 pip install console-cowboy
 ```
-## Usage
 
-For help, run:
+Or with `pipx` for isolated installation:
+
 ```bash
-console-cowboy --help
+pipx install console-cowboy
 ```
-You can also use:
+
+## Quick Start
+
+### Export your current terminal config
+
 ```bash
-python -m console_cowboy --help
+# Export Ghostty config to CTEC format
+console-cowboy export ghostty -o my-config.toml
+
+# Export iTerm2 config
+console-cowboy export iterm2 -o my-config.toml
+
+# Export to JSON format
+console-cowboy export kitty -o my-config.json -f json
 ```
+
+### Import into a different terminal
+
+```bash
+# Import CTEC config into Alacritty format
+console-cowboy import my-config.toml -t alacritty -o ~/.config/alacritty/alacritty.toml
+
+# Import into Wezterm
+console-cowboy import my-config.toml -t wezterm -o ~/.wezterm.lua
+
+# Preview output without saving
+console-cowboy import my-config.toml -t ghostty
+```
+
+### Convert directly between terminals
+
+```bash
+# Convert Kitty config to Ghostty
+console-cowboy convert ~/.config/kitty/kitty.conf -f kitty -t ghostty -o ~/.config/ghostty/config
+
+# Convert iTerm2 to Alacritty
+console-cowboy convert ~/Library/Preferences/com.googlecode.iterm2.plist -f iterm2 -t alacritty
+```
+
+## Commands
+
+### `export`
+
+Export a terminal's configuration to CTEC format.
+
+```bash
+console-cowboy export TERMINAL [-i INPUT] [-o OUTPUT] [-f FORMAT] [-q]
+```
+
+Options:
+- `TERMINAL`: Source terminal (iterm2, ghostty, alacritty, kitty, wezterm)
+- `-i, --input`: Input config file (defaults to terminal's standard location)
+- `-o, --output`: Output file (defaults to stdout)
+- `-f, --format`: Output format: toml, json, yaml (default: toml)
+- `-q, --quiet`: Suppress warnings and informational output
+
+### `import`
+
+Import a CTEC configuration into a terminal's native format.
+
+```bash
+console-cowboy import INPUT_FILE -t TERMINAL [-o OUTPUT] [-f FORMAT] [-q]
+```
+
+Options:
+- `INPUT_FILE`: Path to CTEC configuration file
+- `-t, --terminal`: Target terminal (required)
+- `-o, --output`: Output file (defaults to stdout)
+- `-f, --format`: Input format override (auto-detected from extension)
+- `-q, --quiet`: Suppress warnings
+
+### `convert`
+
+Convert directly between terminal configuration formats.
+
+```bash
+console-cowboy convert INPUT_FILE -f FROM_TERMINAL -t TO_TERMINAL [-o OUTPUT] [-q]
+```
+
+### `list`
+
+List all supported terminal emulators.
+
+```bash
+console-cowboy list
+```
+
+### `info`
+
+Display information about a configuration file.
+
+```bash
+console-cowboy info INPUT_FILE [-t TERMINAL]
+```
+
+## CTEC Format
+
+The Common Terminal Emulator Configuration (CTEC) format is a portable representation of terminal settings. It captures:
+
+### Color Scheme
+- Foreground and background colors
+- Cursor and selection colors
+- Full 16-color ANSI palette (normal and bright variants)
+
+### Font Configuration
+- Font family, size, and line height
+- Bold and italic font variants
+- Ligature support
+
+### Cursor Configuration
+- Style (block, beam, underline)
+- Blink behavior and interval
+
+### Window Configuration
+- Initial dimensions (columns/rows)
+- Opacity and blur effects
+- Padding and decorations
+- Startup mode
+
+### Behavior Configuration
+- Default shell
+- Scrollback buffer size
+- Bell mode (audible, visual, none)
+- Copy-on-select behavior
+
+### Key Bindings
+- Keyboard shortcuts with modifiers
+
+### Terminal-Specific Settings
+Settings that cannot be mapped to common CTEC fields are preserved in a `terminal_specific` section, allowing them to be restored when converting back to the same terminal.
+
+### Example CTEC File
+
+```toml
+version = "1.0"
+source_terminal = "ghostty"
+
+[color_scheme]
+name = "Tomorrow Night"
+
+[color_scheme.foreground]
+r = 197
+g = 200
+b = 198
+
+[color_scheme.background]
+r = 29
+g = 31
+b = 33
+
+[font]
+family = "JetBrains Mono"
+size = 14.0
+ligatures = true
+
+[cursor]
+style = "block"
+blink = true
+blink_interval = 500
+
+[window]
+columns = 120
+rows = 40
+opacity = 0.95
+
+[behavior]
+shell = "/bin/zsh"
+scrollback_lines = 10000
+bell_mode = "visual"
+
+[[key_bindings]]
+action = "Copy"
+key = "c"
+mods = ["ctrl", "shift"]
+```
+
+## Supported Terminals
+
+| Terminal | Config Format | Import | Export |
+|----------|--------------|--------|--------|
+| iTerm2 | plist XML | Yes | Yes |
+| Ghostty | key=value | Yes | Yes |
+| Alacritty | TOML/YAML | Yes | Yes |
+| Kitty | key value | Yes | Yes |
+| Wezterm | Lua | Yes | Yes |
+
+### Default Config Locations
+
+- **iTerm2**: `~/Library/Preferences/com.googlecode.iterm2.plist`
+- **Ghostty**: `~/.config/ghostty/config`
+- **Alacritty**: `~/.config/alacritty/alacritty.toml` or `.yml`
+- **Kitty**: `~/.config/kitty/kitty.conf`
+- **Wezterm**: `~/.wezterm.lua` or `~/.config/wezterm/wezterm.lua`
+
+## Compatibility Notes
+
+Not all settings can be perfectly converted between terminals:
+
+1. **Color Formats**: All terminals use slightly different color representations. Console Cowboy normalizes to RGB and converts appropriately.
+
+2. **Font Handling**: Font names may need adjustment depending on how each terminal resolves fonts.
+
+3. **Key Bindings**: Different terminals have different action names and modifier key representations. Key bindings are converted on a best-effort basis.
+
+4. **Wezterm Lua**: Wezterm uses Lua for configuration. Console Cowboy can parse common patterns but complex Lua configurations may not be fully captured.
+
+5. **Terminal-Specific Features**: Features unique to one terminal (like iTerm2's "Unlimited Scrollback" or Kitty's remote control) are preserved but only work when converting back to the same terminal.
+
+Console Cowboy will report any incompatibilities or settings that couldn't be converted.
+
 ## Development
 
-To contribute to this tool, first checkout the code. Then create a new virtual environment:
+To contribute to this tool, first checkout the code:
+
 ```bash
+git clone https://github.com/zetlen/console-cowboy
 cd console-cowboy
+```
+
+Create a virtual environment and install dependencies:
+
+```bash
 python -m venv venv
 source venv/bin/activate
-```
-Now install the dependencies and test dependencies:
-```bash
 pip install -e '.[test]'
 ```
-To run the tests:
+
+Run the tests:
+
 ```bash
 python -m pytest
 ```
+
+Run tests with coverage:
+
+```bash
+python -m pytest --cov=console_cowboy
+```
+
+## License
+
+Apache 2.0
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
+
+### Adding Support for New Terminals
+
+1. Create a new adapter in `console_cowboy/terminals/`
+2. Inherit from `TerminalAdapter`
+3. Implement `parse()` and `export()` methods
+4. Register the adapter in `console_cowboy/terminals/__init__.py`
+5. Add test fixtures and tests

--- a/console_cowboy/cli.py
+++ b/console_cowboy/cli.py
@@ -1,21 +1,569 @@
+"""
+Console Cowboy CLI - Portable Terminal Configuration Manager.
+
+This CLI enables migration of terminal emulator configurations between
+different terminal applications using the CTEC (Common Terminal Emulator
+Configuration) format as an intermediate representation.
+
+Commands:
+    export: Export a terminal's configuration to CTEC format
+    import: Import a CTEC configuration into a terminal's native format
+    list: List supported terminal emulators
+    convert: Convert directly between terminal configuration formats
+"""
+
+import sys
+from pathlib import Path
+from typing import Optional
+
 import click
+
+from console_cowboy.ctec import CTEC, CTECSerializer
+from console_cowboy.ctec.serializers import OutputFormat
+from console_cowboy.terminals import TerminalRegistry
+
+# Import to trigger registration
+import console_cowboy.terminals  # noqa: F401
+
+
+def get_terminal_choices() -> list[str]:
+    """Get list of available terminal names for CLI choices."""
+    return TerminalRegistry.get_names()
+
+
+def print_warnings(ctec: CTEC) -> None:
+    """Print any warnings from the CTEC configuration."""
+    if ctec.warnings:
+        click.echo(click.style("\nWarnings:", fg="yellow", bold=True), err=True)
+        for warning in ctec.warnings:
+            click.echo(click.style(f"  - {warning}", fg="yellow"), err=True)
+
+
+def print_terminal_specific(ctec: CTEC) -> None:
+    """Print terminal-specific settings that couldn't be mapped."""
+    if ctec.terminal_specific:
+        click.echo(
+            click.style(
+                "\nTerminal-specific settings (not portable):", fg="cyan", bold=True
+            ),
+            err=True,
+        )
+        for setting in ctec.terminal_specific:
+            click.echo(
+                click.style(f"  [{setting.terminal}] {setting.key} = {setting.value}", fg="cyan"),
+                err=True,
+            )
 
 
 @click.group()
 @click.version_option()
 def cli():
-    "Hop terminals like you hop linux distributions."
+    """
+    Console Cowboy - Hop terminals like you hop Linux distributions.
+
+    A tool for making terminal configurations portable across different
+    terminal emulators. Export your settings from one terminal and import
+    them into another.
+
+    Supported terminals: iTerm2, Ghostty, Alacritty, Kitty, Wezterm
+
+    \b
+    Examples:
+        # Export iTerm2 config to CTEC format
+        console-cowboy export iterm2 -o my-config.toml
+
+        # Import CTEC config into Ghostty format
+        console-cowboy import my-config.toml -t ghostty -o ~/.config/ghostty/config
+
+        # Convert directly between terminals
+        console-cowboy convert ~/.config/kitty/kitty.conf -f kitty -t alacritty
+    """
+    pass
 
 
-@cli.command(name="command")
+@cli.command(name="list")
+def list_terminals():
+    """
+    List all supported terminal emulators.
+
+    Shows terminal names that can be used with the export, import, and
+    convert commands.
+    """
+    click.echo(click.style("Supported terminal emulators:", bold=True))
+    click.echo()
+    for adapter in TerminalRegistry.list_terminals():
+        click.echo(click.style(f"  {adapter.name}", fg="green", bold=True))
+        click.echo(f"    {adapter.display_name}: {adapter.description}")
+        if adapter.default_config_paths:
+            paths = ", ".join(f"~/{p}" for p in adapter.default_config_paths)
+            click.echo(click.style(f"    Config: {paths}", dim=True))
+        click.echo()
+
+
+@cli.command(name="export")
 @click.argument(
-    "example"
+    "terminal",
+    type=click.Choice(get_terminal_choices(), case_sensitive=False),
+)
+@click.option(
+    "-i",
+    "--input",
+    "input_path",
+    type=click.Path(exists=True, path_type=Path),
+    help="Input configuration file. If not specified, uses the terminal's default location.",
 )
 @click.option(
     "-o",
-    "--option",
-    help="An example option",
+    "--output",
+    "output_path",
+    type=click.Path(path_type=Path),
+    help="Output file path. If not specified, outputs to stdout.",
 )
-def first_command(example, option):
-    "Command description goes here"
-    click.echo("Here is some output")
+@click.option(
+    "-f",
+    "--format",
+    "output_format",
+    type=click.Choice(["toml", "json", "yaml"], case_sensitive=False),
+    default="toml",
+    help="Output format (default: toml).",
+)
+@click.option(
+    "-q",
+    "--quiet",
+    is_flag=True,
+    help="Suppress warnings and informational output.",
+)
+def export_config(
+    terminal: str,
+    input_path: Optional[Path],
+    output_path: Optional[Path],
+    output_format: str,
+    quiet: bool,
+):
+    """
+    Export a terminal's configuration to CTEC format.
+
+    TERMINAL is the name of the source terminal emulator (e.g., iterm2, ghostty).
+
+    \b
+    Examples:
+        # Export iTerm2 config to TOML
+        console-cowboy export iterm2 -o my-config.toml
+
+        # Export from a specific file
+        console-cowboy export ghostty -i ~/custom/config -o config.json -f json
+
+        # Export to stdout
+        console-cowboy export kitty
+    """
+    adapter = TerminalRegistry.get(terminal)
+    if not adapter:
+        raise click.ClickException(f"Unknown terminal: {terminal}")
+
+    # Determine input path
+    if input_path is None:
+        input_path = adapter.get_default_config_path()
+        if input_path is None:
+            raise click.ClickException(
+                f"Could not find default config for {terminal}. "
+                f"Please specify input file with -i/--input."
+            )
+        if not quiet:
+            click.echo(
+                f"Using default config: {input_path}",
+                err=True,
+            )
+
+    # Parse configuration
+    try:
+        ctec = adapter.parse(input_path)
+    except FileNotFoundError as e:
+        raise click.ClickException(str(e))
+    except Exception as e:
+        raise click.ClickException(f"Failed to parse {terminal} config: {e}")
+
+    # Serialize to output format
+    fmt = OutputFormat(output_format.lower())
+    output = CTECSerializer.serialize(ctec, fmt)
+
+    # Write output
+    if output_path:
+        output_path.write_text(output)
+        if not quiet:
+            click.echo(f"Exported to {output_path}", err=True)
+    else:
+        click.echo(output)
+
+    # Print warnings and terminal-specific settings
+    if not quiet:
+        print_warnings(ctec)
+        print_terminal_specific(ctec)
+
+
+@cli.command(name="import")
+@click.argument(
+    "input_file",
+    type=click.Path(exists=True, path_type=Path),
+)
+@click.option(
+    "-t",
+    "--terminal",
+    "terminal",
+    type=click.Choice(get_terminal_choices(), case_sensitive=False),
+    required=True,
+    help="Target terminal emulator to convert to.",
+)
+@click.option(
+    "-o",
+    "--output",
+    "output_path",
+    type=click.Path(path_type=Path),
+    help="Output file path. If not specified, outputs to stdout.",
+)
+@click.option(
+    "-f",
+    "--format",
+    "input_format",
+    type=click.Choice(["toml", "json", "yaml"], case_sensitive=False),
+    help="Input format. If not specified, detected from file extension.",
+)
+@click.option(
+    "-q",
+    "--quiet",
+    is_flag=True,
+    help="Suppress warnings and informational output.",
+)
+def import_config(
+    input_file: Path,
+    terminal: str,
+    output_path: Optional[Path],
+    input_format: Optional[str],
+    quiet: bool,
+):
+    """
+    Import a CTEC configuration into a terminal's native format.
+
+    INPUT_FILE is the path to a CTEC configuration file (.toml, .json, or .yaml).
+
+    \b
+    Examples:
+        # Import CTEC config into Ghostty format
+        console-cowboy import config.toml -t ghostty -o ~/.config/ghostty/config
+
+        # Import and output to stdout
+        console-cowboy import config.toml -t alacritty
+
+        # Specify input format explicitly
+        console-cowboy import config -t kitty -f toml
+    """
+    adapter = TerminalRegistry.get(terminal)
+    if not adapter:
+        raise click.ClickException(f"Unknown terminal: {terminal}")
+
+    # Determine input format
+    fmt = None
+    if input_format:
+        fmt = OutputFormat(input_format.lower())
+    else:
+        try:
+            fmt = CTECSerializer.detect_format(input_file)
+        except ValueError:
+            raise click.ClickException(
+                f"Cannot detect format from extension. "
+                f"Please specify with -f/--format."
+            )
+
+    # Parse CTEC configuration
+    try:
+        ctec = CTECSerializer.read_file(input_file, fmt)
+    except Exception as e:
+        raise click.ClickException(f"Failed to read CTEC config: {e}")
+
+    # Export to target format
+    try:
+        output = adapter.export(ctec)
+    except Exception as e:
+        raise click.ClickException(f"Failed to export to {terminal} format: {e}")
+
+    # Write output
+    if output_path:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(output)
+        if not quiet:
+            click.echo(f"Imported to {output_path}", err=True)
+    else:
+        click.echo(output)
+
+    # Print warnings
+    if not quiet:
+        print_warnings(ctec)
+
+        # Check for incompatibilities
+        if ctec.source_terminal and ctec.source_terminal != terminal:
+            source_specific = ctec.get_terminal_specific(ctec.source_terminal)
+            if source_specific:
+                click.echo(
+                    click.style(
+                        f"\nNote: {len(source_specific)} setting(s) from "
+                        f"{ctec.source_terminal} could not be converted to {terminal}.",
+                        fg="yellow",
+                    ),
+                    err=True,
+                )
+
+
+@cli.command(name="convert")
+@click.argument(
+    "input_file",
+    type=click.Path(exists=True, path_type=Path),
+)
+@click.option(
+    "-f",
+    "--from",
+    "from_terminal",
+    type=click.Choice(get_terminal_choices(), case_sensitive=False),
+    required=True,
+    help="Source terminal emulator.",
+)
+@click.option(
+    "-t",
+    "--to",
+    "to_terminal",
+    type=click.Choice(get_terminal_choices(), case_sensitive=False),
+    required=True,
+    help="Target terminal emulator.",
+)
+@click.option(
+    "-o",
+    "--output",
+    "output_path",
+    type=click.Path(path_type=Path),
+    help="Output file path. If not specified, outputs to stdout.",
+)
+@click.option(
+    "-q",
+    "--quiet",
+    is_flag=True,
+    help="Suppress warnings and informational output.",
+)
+def convert_config(
+    input_file: Path,
+    from_terminal: str,
+    to_terminal: str,
+    output_path: Optional[Path],
+    quiet: bool,
+):
+    """
+    Convert directly between terminal configuration formats.
+
+    This is a convenience command that combines export and import in one step.
+
+    \b
+    Examples:
+        # Convert Kitty config to Alacritty
+        console-cowboy convert kitty.conf -f kitty -t alacritty -o alacritty.toml
+
+        # Convert iTerm2 plist to Ghostty
+        console-cowboy convert com.googlecode.iterm2.plist -f iterm2 -t ghostty
+    """
+    from_adapter = TerminalRegistry.get(from_terminal)
+    to_adapter = TerminalRegistry.get(to_terminal)
+
+    if not from_adapter:
+        raise click.ClickException(f"Unknown source terminal: {from_terminal}")
+    if not to_adapter:
+        raise click.ClickException(f"Unknown target terminal: {to_terminal}")
+
+    # Parse source configuration
+    try:
+        ctec = from_adapter.parse(input_file)
+    except FileNotFoundError as e:
+        raise click.ClickException(str(e))
+    except Exception as e:
+        raise click.ClickException(f"Failed to parse {from_terminal} config: {e}")
+
+    # Export to target format
+    try:
+        output = to_adapter.export(ctec)
+    except Exception as e:
+        raise click.ClickException(f"Failed to export to {to_terminal} format: {e}")
+
+    # Write output
+    if output_path:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(output)
+        if not quiet:
+            click.echo(
+                f"Converted {from_terminal} -> {to_terminal}: {output_path}",
+                err=True,
+            )
+    else:
+        click.echo(output)
+
+    # Print warnings and incompatibilities
+    if not quiet:
+        print_warnings(ctec)
+
+        source_specific = ctec.get_terminal_specific(from_terminal)
+        if source_specific:
+            click.echo(
+                click.style(
+                    f"\nNote: {len(source_specific)} {from_terminal}-specific setting(s) "
+                    f"could not be converted:",
+                    fg="yellow",
+                ),
+                err=True,
+            )
+            for setting in source_specific:
+                click.echo(
+                    click.style(f"  - {setting.key}", fg="yellow"),
+                    err=True,
+                )
+
+
+@cli.command(name="info")
+@click.argument(
+    "input_file",
+    type=click.Path(exists=True, path_type=Path),
+)
+@click.option(
+    "-t",
+    "--terminal",
+    "terminal",
+    type=click.Choice(get_terminal_choices(), case_sensitive=False),
+    help="Terminal type (if parsing native config). If not specified, assumes CTEC format.",
+)
+def show_info(input_file: Path, terminal: Optional[str]):
+    """
+    Display information about a configuration file.
+
+    Shows what settings are present and what can/cannot be ported
+    to other terminals.
+
+    \b
+    Examples:
+        # Show info about a CTEC file
+        console-cowboy info my-config.toml
+
+        # Show info about a native terminal config
+        console-cowboy info ~/.config/kitty/kitty.conf -t kitty
+    """
+    # Parse the configuration
+    if terminal:
+        adapter = TerminalRegistry.get(terminal)
+        if not adapter:
+            raise click.ClickException(f"Unknown terminal: {terminal}")
+        try:
+            ctec = adapter.parse(input_file)
+        except Exception as e:
+            raise click.ClickException(f"Failed to parse config: {e}")
+    else:
+        try:
+            fmt = CTECSerializer.detect_format(input_file)
+            ctec = CTECSerializer.read_file(input_file, fmt)
+        except ValueError:
+            raise click.ClickException(
+                "Cannot detect format. Use -t to specify terminal type."
+            )
+        except Exception as e:
+            raise click.ClickException(f"Failed to parse CTEC config: {e}")
+
+    # Display information
+    click.echo(click.style("Configuration Summary", bold=True, underline=True))
+    click.echo()
+
+    if ctec.source_terminal:
+        click.echo(f"Source terminal: {click.style(ctec.source_terminal, fg='green')}")
+
+    click.echo(f"CTEC version: {ctec.version}")
+    click.echo()
+
+    # Colors
+    if ctec.color_scheme:
+        click.echo(click.style("Color Scheme:", bold=True))
+        scheme = ctec.color_scheme
+        color_count = sum(
+            1
+            for attr in [
+                "foreground",
+                "background",
+                "cursor",
+                "black",
+                "red",
+                "green",
+            ]
+            if getattr(scheme, attr, None)
+        )
+        click.echo(f"  Defined colors: {color_count}+")
+        if scheme.name:
+            click.echo(f"  Name: {scheme.name}")
+        click.echo()
+
+    # Font
+    if ctec.font:
+        click.echo(click.style("Font:", bold=True))
+        if ctec.font.family:
+            click.echo(f"  Family: {ctec.font.family}")
+        if ctec.font.size:
+            click.echo(f"  Size: {ctec.font.size}")
+        click.echo()
+
+    # Cursor
+    if ctec.cursor:
+        click.echo(click.style("Cursor:", bold=True))
+        if ctec.cursor.style:
+            click.echo(f"  Style: {ctec.cursor.style.value}")
+        if ctec.cursor.blink is not None:
+            click.echo(f"  Blink: {ctec.cursor.blink}")
+        click.echo()
+
+    # Window
+    if ctec.window:
+        click.echo(click.style("Window:", bold=True))
+        if ctec.window.columns:
+            click.echo(f"  Columns: {ctec.window.columns}")
+        if ctec.window.rows:
+            click.echo(f"  Rows: {ctec.window.rows}")
+        if ctec.window.opacity is not None:
+            click.echo(f"  Opacity: {ctec.window.opacity}")
+        click.echo()
+
+    # Behavior
+    if ctec.behavior:
+        click.echo(click.style("Behavior:", bold=True))
+        if ctec.behavior.shell:
+            click.echo(f"  Shell: {ctec.behavior.shell}")
+        if ctec.behavior.scrollback_lines is not None:
+            click.echo(f"  Scrollback: {ctec.behavior.scrollback_lines} lines")
+        click.echo()
+
+    # Key bindings
+    if ctec.key_bindings:
+        click.echo(click.style("Key Bindings:", bold=True))
+        click.echo(f"  Defined: {len(ctec.key_bindings)}")
+        click.echo()
+
+    # Profiles
+    if ctec.profiles:
+        click.echo(click.style("Profiles:", bold=True))
+        for profile in ctec.profiles:
+            marker = " (default)" if profile.is_default else ""
+            click.echo(f"  - {profile.name}{marker}")
+        click.echo()
+
+    # Terminal-specific
+    if ctec.terminal_specific:
+        click.echo(click.style("Terminal-Specific Settings:", bold=True))
+        by_terminal: dict[str, int] = {}
+        for setting in ctec.terminal_specific:
+            by_terminal[setting.terminal] = by_terminal.get(setting.terminal, 0) + 1
+        for term, count in by_terminal.items():
+            click.echo(f"  {term}: {count} setting(s)")
+        click.echo()
+
+    # Warnings
+    print_warnings(ctec)
+
+
+if __name__ == "__main__":
+    cli()

--- a/console_cowboy/ctec/__init__.py
+++ b/console_cowboy/ctec/__init__.py
@@ -1,0 +1,38 @@
+"""
+CTEC - Common Terminal Emulator Configuration
+
+A portable configuration format for terminal emulators that enables
+migration of settings between different terminal applications.
+"""
+
+from .schema import (
+    CTEC,
+    ColorScheme,
+    Color,
+    FontConfig,
+    CursorConfig,
+    CursorStyle,
+    WindowConfig,
+    BehaviorConfig,
+    BellMode,
+    KeyBinding,
+    Profile,
+    TerminalSpecificSetting,
+)
+from .serializers import CTECSerializer
+
+__all__ = [
+    "CTEC",
+    "ColorScheme",
+    "Color",
+    "FontConfig",
+    "CursorConfig",
+    "CursorStyle",
+    "WindowConfig",
+    "BehaviorConfig",
+    "BellMode",
+    "KeyBinding",
+    "Profile",
+    "TerminalSpecificSetting",
+    "CTECSerializer",
+]

--- a/console_cowboy/ctec/schema.py
+++ b/console_cowboy/ctec/schema.py
@@ -1,0 +1,617 @@
+"""
+CTEC Schema - Data model for Common Terminal Emulator Configuration.
+
+This module defines the portable configuration format that serves as an
+intermediate representation for terminal emulator settings.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+
+class CursorStyle(Enum):
+    """Cursor appearance styles supported by most terminal emulators."""
+
+    BLOCK = "block"
+    BEAM = "beam"
+    UNDERLINE = "underline"
+
+
+class BellMode(Enum):
+    """Bell notification modes."""
+
+    NONE = "none"
+    AUDIBLE = "audible"
+    VISUAL = "visual"
+
+
+@dataclass
+class Color:
+    """
+    Represents an RGB color.
+
+    Attributes:
+        r: Red component (0-255)
+        g: Green component (0-255)
+        b: Blue component (0-255)
+    """
+
+    r: int
+    g: int
+    b: int
+
+    def __post_init__(self) -> None:
+        for component, name in [(self.r, "r"), (self.g, "g"), (self.b, "b")]:
+            if not 0 <= component <= 255:
+                raise ValueError(f"Color component {name} must be 0-255, got {component}")
+
+    def to_hex(self) -> str:
+        """Convert to hex color string (e.g., '#ff0000')."""
+        return f"#{self.r:02x}{self.g:02x}{self.b:02x}"
+
+    @classmethod
+    def from_hex(cls, hex_str: str) -> "Color":
+        """Create a Color from a hex string (e.g., '#ff0000' or 'ff0000')."""
+        hex_str = hex_str.lstrip("#")
+        if len(hex_str) == 3:
+            hex_str = "".join(c * 2 for c in hex_str)
+        if len(hex_str) != 6:
+            raise ValueError(f"Invalid hex color: {hex_str}")
+        return cls(
+            r=int(hex_str[0:2], 16),
+            g=int(hex_str[2:4], 16),
+            b=int(hex_str[4:6], 16),
+        )
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary representation."""
+        return {"r": self.r, "g": self.g, "b": self.b}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Color":
+        """Create a Color from a dictionary."""
+        return cls(r=data["r"], g=data["g"], b=data["b"])
+
+
+@dataclass
+class ColorScheme:
+    """
+    Terminal color scheme with ANSI colors and semantic colors.
+
+    Attributes:
+        name: Optional name for the color scheme
+        foreground: Default text color
+        background: Default background color
+        cursor: Cursor color
+        cursor_text: Text color when under cursor
+        selection: Selection highlight color
+        selection_text: Selected text color
+        black: ANSI color 0 (normal)
+        red: ANSI color 1 (normal)
+        green: ANSI color 2 (normal)
+        yellow: ANSI color 3 (normal)
+        blue: ANSI color 4 (normal)
+        magenta: ANSI color 5 (normal)
+        cyan: ANSI color 6 (normal)
+        white: ANSI color 7 (normal)
+        bright_black: ANSI color 8 (bright)
+        bright_red: ANSI color 9 (bright)
+        bright_green: ANSI color 10 (bright)
+        bright_yellow: ANSI color 11 (bright)
+        bright_blue: ANSI color 12 (bright)
+        bright_magenta: ANSI color 13 (bright)
+        bright_cyan: ANSI color 14 (bright)
+        bright_white: ANSI color 15 (bright)
+    """
+
+    name: Optional[str] = None
+    foreground: Optional[Color] = None
+    background: Optional[Color] = None
+    cursor: Optional[Color] = None
+    cursor_text: Optional[Color] = None
+    selection: Optional[Color] = None
+    selection_text: Optional[Color] = None
+    # Normal colors (0-7)
+    black: Optional[Color] = None
+    red: Optional[Color] = None
+    green: Optional[Color] = None
+    yellow: Optional[Color] = None
+    blue: Optional[Color] = None
+    magenta: Optional[Color] = None
+    cyan: Optional[Color] = None
+    white: Optional[Color] = None
+    # Bright colors (8-15)
+    bright_black: Optional[Color] = None
+    bright_red: Optional[Color] = None
+    bright_green: Optional[Color] = None
+    bright_yellow: Optional[Color] = None
+    bright_blue: Optional[Color] = None
+    bright_magenta: Optional[Color] = None
+    bright_cyan: Optional[Color] = None
+    bright_white: Optional[Color] = None
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary representation."""
+        result = {}
+        if self.name is not None:
+            result["name"] = self.name
+        color_fields = [
+            "foreground",
+            "background",
+            "cursor",
+            "cursor_text",
+            "selection",
+            "selection_text",
+            "black",
+            "red",
+            "green",
+            "yellow",
+            "blue",
+            "magenta",
+            "cyan",
+            "white",
+            "bright_black",
+            "bright_red",
+            "bright_green",
+            "bright_yellow",
+            "bright_blue",
+            "bright_magenta",
+            "bright_cyan",
+            "bright_white",
+        ]
+        for field_name in color_fields:
+            color = getattr(self, field_name)
+            if color is not None:
+                result[field_name] = color.to_dict()
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ColorScheme":
+        """Create a ColorScheme from a dictionary."""
+        kwargs = {}
+        if "name" in data:
+            kwargs["name"] = data["name"]
+        color_fields = [
+            "foreground",
+            "background",
+            "cursor",
+            "cursor_text",
+            "selection",
+            "selection_text",
+            "black",
+            "red",
+            "green",
+            "yellow",
+            "blue",
+            "magenta",
+            "cyan",
+            "white",
+            "bright_black",
+            "bright_red",
+            "bright_green",
+            "bright_yellow",
+            "bright_blue",
+            "bright_magenta",
+            "bright_cyan",
+            "bright_white",
+        ]
+        for field_name in color_fields:
+            if field_name in data:
+                kwargs[field_name] = Color.from_dict(data[field_name])
+        return cls(**kwargs)
+
+
+@dataclass
+class FontConfig:
+    """
+    Font configuration for the terminal.
+
+    Attributes:
+        family: Font family name (e.g., 'JetBrains Mono', 'Fira Code')
+        size: Font size in points
+        line_height: Line height multiplier (1.0 = normal)
+        bold_font: Optional separate font family for bold text
+        italic_font: Optional separate font family for italic text
+        ligatures: Whether to enable font ligatures
+    """
+
+    family: Optional[str] = None
+    size: Optional[float] = None
+    line_height: Optional[float] = None
+    bold_font: Optional[str] = None
+    italic_font: Optional[str] = None
+    ligatures: Optional[bool] = None
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary representation."""
+        result = {}
+        for field_name in [
+            "family",
+            "size",
+            "line_height",
+            "bold_font",
+            "italic_font",
+            "ligatures",
+        ]:
+            value = getattr(self, field_name)
+            if value is not None:
+                result[field_name] = value
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "FontConfig":
+        """Create a FontConfig from a dictionary."""
+        return cls(
+            family=data.get("family"),
+            size=data.get("size"),
+            line_height=data.get("line_height"),
+            bold_font=data.get("bold_font"),
+            italic_font=data.get("italic_font"),
+            ligatures=data.get("ligatures"),
+        )
+
+
+@dataclass
+class CursorConfig:
+    """
+    Cursor appearance and behavior configuration.
+
+    Attributes:
+        style: Cursor shape (block, beam, or underline)
+        blink: Whether the cursor should blink
+        blink_interval: Blink interval in milliseconds
+    """
+
+    style: Optional[CursorStyle] = None
+    blink: Optional[bool] = None
+    blink_interval: Optional[int] = None
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary representation."""
+        result = {}
+        if self.style is not None:
+            result["style"] = self.style.value
+        if self.blink is not None:
+            result["blink"] = self.blink
+        if self.blink_interval is not None:
+            result["blink_interval"] = self.blink_interval
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "CursorConfig":
+        """Create a CursorConfig from a dictionary."""
+        return cls(
+            style=CursorStyle(data["style"]) if "style" in data else None,
+            blink=data.get("blink"),
+            blink_interval=data.get("blink_interval"),
+        )
+
+
+@dataclass
+class WindowConfig:
+    """
+    Window appearance and behavior configuration.
+
+    Attributes:
+        columns: Initial number of columns
+        rows: Initial number of rows
+        opacity: Window opacity (0.0 = transparent, 1.0 = opaque)
+        blur: Background blur radius (0 = no blur)
+        padding_horizontal: Horizontal padding in pixels
+        padding_vertical: Vertical padding in pixels
+        decorations: Whether to show window decorations (title bar, etc.)
+        startup_mode: Initial window mode ('windowed', 'maximized', 'fullscreen')
+        dynamic_title: Whether to update window title from shell
+    """
+
+    columns: Optional[int] = None
+    rows: Optional[int] = None
+    opacity: Optional[float] = None
+    blur: Optional[int] = None
+    padding_horizontal: Optional[int] = None
+    padding_vertical: Optional[int] = None
+    decorations: Optional[bool] = None
+    startup_mode: Optional[str] = None
+    dynamic_title: Optional[bool] = None
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary representation."""
+        result = {}
+        for field_name in [
+            "columns",
+            "rows",
+            "opacity",
+            "blur",
+            "padding_horizontal",
+            "padding_vertical",
+            "decorations",
+            "startup_mode",
+            "dynamic_title",
+        ]:
+            value = getattr(self, field_name)
+            if value is not None:
+                result[field_name] = value
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "WindowConfig":
+        """Create a WindowConfig from a dictionary."""
+        return cls(
+            columns=data.get("columns"),
+            rows=data.get("rows"),
+            opacity=data.get("opacity"),
+            blur=data.get("blur"),
+            padding_horizontal=data.get("padding_horizontal"),
+            padding_vertical=data.get("padding_vertical"),
+            decorations=data.get("decorations"),
+            startup_mode=data.get("startup_mode"),
+            dynamic_title=data.get("dynamic_title"),
+        )
+
+
+@dataclass
+class BehaviorConfig:
+    """
+    Terminal behavior configuration.
+
+    Attributes:
+        shell: Shell command or path to execute
+        working_directory: Initial working directory
+        scrollback_lines: Number of lines to keep in scrollback buffer
+        mouse_enabled: Whether to enable mouse support
+        bell_mode: Bell notification mode
+        copy_on_select: Whether to copy text to clipboard on selection
+        confirm_close: Whether to confirm before closing with running processes
+        close_on_exit: Action when shell exits ('close', 'hold', 'restart')
+    """
+
+    shell: Optional[str] = None
+    working_directory: Optional[str] = None
+    scrollback_lines: Optional[int] = None
+    mouse_enabled: Optional[bool] = None
+    bell_mode: Optional[BellMode] = None
+    copy_on_select: Optional[bool] = None
+    confirm_close: Optional[bool] = None
+    close_on_exit: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary representation."""
+        result = {}
+        for field_name in [
+            "shell",
+            "working_directory",
+            "scrollback_lines",
+            "mouse_enabled",
+            "copy_on_select",
+            "confirm_close",
+            "close_on_exit",
+        ]:
+            value = getattr(self, field_name)
+            if value is not None:
+                result[field_name] = value
+        if self.bell_mode is not None:
+            result["bell_mode"] = self.bell_mode.value
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "BehaviorConfig":
+        """Create a BehaviorConfig from a dictionary."""
+        return cls(
+            shell=data.get("shell"),
+            working_directory=data.get("working_directory"),
+            scrollback_lines=data.get("scrollback_lines"),
+            mouse_enabled=data.get("mouse_enabled"),
+            bell_mode=BellMode(data["bell_mode"]) if "bell_mode" in data else None,
+            copy_on_select=data.get("copy_on_select"),
+            confirm_close=data.get("confirm_close"),
+            close_on_exit=data.get("close_on_exit"),
+        )
+
+
+@dataclass
+class KeyBinding:
+    """
+    A keyboard shortcut binding.
+
+    Attributes:
+        action: The action to perform (e.g., 'copy', 'paste', 'new_tab')
+        key: The key (e.g., 'c', 'v', 'Return')
+        mods: Modifier keys (e.g., ['ctrl'], ['ctrl', 'shift'])
+    """
+
+    action: str
+    key: str
+    mods: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary representation."""
+        result = {"action": self.action, "key": self.key}
+        if self.mods:
+            result["mods"] = self.mods
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "KeyBinding":
+        """Create a KeyBinding from a dictionary."""
+        return cls(
+            action=data["action"],
+            key=data["key"],
+            mods=data.get("mods", []),
+        )
+
+
+@dataclass
+class TerminalSpecificSetting:
+    """
+    A setting specific to a particular terminal emulator that cannot
+    be mapped to a common CTEC setting.
+
+    Attributes:
+        terminal: Terminal emulator name (e.g., 'iterm2', 'ghostty')
+        key: Configuration key path (e.g., 'Unlimited Scrollback')
+        value: Configuration value (any serializable type)
+    """
+
+    terminal: str
+    key: str
+    value: object
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary representation."""
+        return {"terminal": self.terminal, "key": self.key, "value": self.value}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "TerminalSpecificSetting":
+        """Create a TerminalSpecificSetting from a dictionary."""
+        return cls(terminal=data["terminal"], key=data["key"], value=data["value"])
+
+
+@dataclass
+class Profile:
+    """
+    A terminal profile with its own set of configurations.
+
+    Attributes:
+        name: Profile name
+        color_scheme: Color scheme for this profile
+        font: Font configuration for this profile
+        cursor: Cursor configuration for this profile
+        behavior: Behavior configuration for this profile
+        is_default: Whether this is the default profile
+    """
+
+    name: str
+    color_scheme: Optional[ColorScheme] = None
+    font: Optional[FontConfig] = None
+    cursor: Optional[CursorConfig] = None
+    behavior: Optional[BehaviorConfig] = None
+    is_default: bool = False
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary representation."""
+        result = {"name": self.name, "is_default": self.is_default}
+        if self.color_scheme is not None:
+            result["color_scheme"] = self.color_scheme.to_dict()
+        if self.font is not None:
+            result["font"] = self.font.to_dict()
+        if self.cursor is not None:
+            result["cursor"] = self.cursor.to_dict()
+        if self.behavior is not None:
+            result["behavior"] = self.behavior.to_dict()
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Profile":
+        """Create a Profile from a dictionary."""
+        return cls(
+            name=data["name"],
+            color_scheme=ColorScheme.from_dict(data["color_scheme"])
+            if "color_scheme" in data
+            else None,
+            font=FontConfig.from_dict(data["font"]) if "font" in data else None,
+            cursor=CursorConfig.from_dict(data["cursor"]) if "cursor" in data else None,
+            behavior=BehaviorConfig.from_dict(data["behavior"])
+            if "behavior" in data
+            else None,
+            is_default=data.get("is_default", False),
+        )
+
+
+@dataclass
+class CTEC:
+    """
+    Common Terminal Emulator Configuration.
+
+    The main container for all portable terminal configuration settings.
+    This serves as the intermediate format for converting between different
+    terminal emulator configurations.
+
+    Attributes:
+        version: CTEC format version
+        source_terminal: Original terminal emulator this config was exported from
+        color_scheme: Global color scheme (used if no profile specified)
+        font: Global font configuration
+        cursor: Global cursor configuration
+        window: Window configuration
+        behavior: Terminal behavior configuration
+        key_bindings: List of keyboard shortcuts
+        profiles: List of terminal profiles
+        terminal_specific: Settings that cannot be mapped to common CTEC fields
+        warnings: Compatibility warnings generated during import/export
+    """
+
+    version: str = "1.0"
+    source_terminal: Optional[str] = None
+    color_scheme: Optional[ColorScheme] = None
+    font: Optional[FontConfig] = None
+    cursor: Optional[CursorConfig] = None
+    window: Optional[WindowConfig] = None
+    behavior: Optional[BehaviorConfig] = None
+    key_bindings: list[KeyBinding] = field(default_factory=list)
+    profiles: list[Profile] = field(default_factory=list)
+    terminal_specific: list[TerminalSpecificSetting] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary representation suitable for serialization."""
+        result = {"version": self.version}
+        if self.source_terminal is not None:
+            result["source_terminal"] = self.source_terminal
+        if self.color_scheme is not None:
+            result["color_scheme"] = self.color_scheme.to_dict()
+        if self.font is not None:
+            result["font"] = self.font.to_dict()
+        if self.cursor is not None:
+            result["cursor"] = self.cursor.to_dict()
+        if self.window is not None:
+            result["window"] = self.window.to_dict()
+        if self.behavior is not None:
+            result["behavior"] = self.behavior.to_dict()
+        if self.key_bindings:
+            result["key_bindings"] = [kb.to_dict() for kb in self.key_bindings]
+        if self.profiles:
+            result["profiles"] = [p.to_dict() for p in self.profiles]
+        if self.terminal_specific:
+            result["terminal_specific"] = [ts.to_dict() for ts in self.terminal_specific]
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "CTEC":
+        """Create a CTEC from a dictionary."""
+        return cls(
+            version=data.get("version", "1.0"),
+            source_terminal=data.get("source_terminal"),
+            color_scheme=ColorScheme.from_dict(data["color_scheme"])
+            if "color_scheme" in data
+            else None,
+            font=FontConfig.from_dict(data["font"]) if "font" in data else None,
+            cursor=CursorConfig.from_dict(data["cursor"]) if "cursor" in data else None,
+            window=WindowConfig.from_dict(data["window"]) if "window" in data else None,
+            behavior=BehaviorConfig.from_dict(data["behavior"])
+            if "behavior" in data
+            else None,
+            key_bindings=[KeyBinding.from_dict(kb) for kb in data.get("key_bindings", [])],
+            profiles=[Profile.from_dict(p) for p in data.get("profiles", [])],
+            terminal_specific=[
+                TerminalSpecificSetting.from_dict(ts)
+                for ts in data.get("terminal_specific", [])
+            ],
+            warnings=data.get("warnings", []),
+        )
+
+    def add_warning(self, warning: str) -> None:
+        """Add a compatibility warning."""
+        self.warnings.append(warning)
+
+    def add_terminal_specific(
+        self, terminal: str, key: str, value: object
+    ) -> None:
+        """Add a terminal-specific setting."""
+        self.terminal_specific.append(
+            TerminalSpecificSetting(terminal=terminal, key=key, value=value)
+        )
+
+    def get_terminal_specific(self, terminal: str) -> list[TerminalSpecificSetting]:
+        """Get all terminal-specific settings for a given terminal."""
+        return [ts for ts in self.terminal_specific if ts.terminal == terminal]

--- a/console_cowboy/ctec/serializers.py
+++ b/console_cowboy/ctec/serializers.py
@@ -1,0 +1,218 @@
+"""
+CTEC Serializers - JSON, YAML, and TOML serialization for CTEC configurations.
+"""
+
+import json
+from enum import Enum
+from pathlib import Path
+from typing import Union
+
+import tomli
+import tomli_w
+import yaml
+
+from .schema import CTEC
+
+
+class OutputFormat(Enum):
+    """Supported output formats for CTEC serialization."""
+
+    TOML = "toml"
+    JSON = "json"
+    YAML = "yaml"
+
+
+class CTECSerializer:
+    """
+    Serializer for CTEC configurations.
+
+    Supports reading and writing CTEC configs in TOML, JSON, and YAML formats.
+    """
+
+    @staticmethod
+    def to_toml(ctec: CTEC) -> str:
+        """
+        Serialize CTEC to TOML string.
+
+        Args:
+            ctec: The CTEC configuration to serialize
+
+        Returns:
+            TOML string representation
+        """
+        return tomli_w.dumps(ctec.to_dict())
+
+    @staticmethod
+    def to_json(ctec: CTEC, indent: int = 2) -> str:
+        """
+        Serialize CTEC to JSON string.
+
+        Args:
+            ctec: The CTEC configuration to serialize
+            indent: JSON indentation level
+
+        Returns:
+            JSON string representation
+        """
+        return json.dumps(ctec.to_dict(), indent=indent)
+
+    @staticmethod
+    def to_yaml(ctec: CTEC) -> str:
+        """
+        Serialize CTEC to YAML string.
+
+        Args:
+            ctec: The CTEC configuration to serialize
+
+        Returns:
+            YAML string representation
+        """
+        return yaml.dump(ctec.to_dict(), default_flow_style=False, sort_keys=False)
+
+    @staticmethod
+    def serialize(ctec: CTEC, format: OutputFormat) -> str:
+        """
+        Serialize CTEC to the specified format.
+
+        Args:
+            ctec: The CTEC configuration to serialize
+            format: Output format (TOML, JSON, or YAML)
+
+        Returns:
+            String representation in the specified format
+        """
+        if format == OutputFormat.TOML:
+            return CTECSerializer.to_toml(ctec)
+        elif format == OutputFormat.JSON:
+            return CTECSerializer.to_json(ctec)
+        elif format == OutputFormat.YAML:
+            return CTECSerializer.to_yaml(ctec)
+        else:
+            raise ValueError(f"Unsupported format: {format}")
+
+    @staticmethod
+    def from_toml(content: str) -> CTEC:
+        """
+        Deserialize CTEC from TOML string.
+
+        Args:
+            content: TOML string
+
+        Returns:
+            CTEC configuration
+        """
+        data = tomli.loads(content)
+        return CTEC.from_dict(data)
+
+    @staticmethod
+    def from_json(content: str) -> CTEC:
+        """
+        Deserialize CTEC from JSON string.
+
+        Args:
+            content: JSON string
+
+        Returns:
+            CTEC configuration
+        """
+        data = json.loads(content)
+        return CTEC.from_dict(data)
+
+    @staticmethod
+    def from_yaml(content: str) -> CTEC:
+        """
+        Deserialize CTEC from YAML string.
+
+        Args:
+            content: YAML string
+
+        Returns:
+            CTEC configuration
+        """
+        data = yaml.safe_load(content)
+        return CTEC.from_dict(data)
+
+    @staticmethod
+    def deserialize(content: str, format: OutputFormat) -> CTEC:
+        """
+        Deserialize CTEC from the specified format.
+
+        Args:
+            content: String content to deserialize
+            format: Input format (TOML, JSON, or YAML)
+
+        Returns:
+            CTEC configuration
+        """
+        if format == OutputFormat.TOML:
+            return CTECSerializer.from_toml(content)
+        elif format == OutputFormat.JSON:
+            return CTECSerializer.from_json(content)
+        elif format == OutputFormat.YAML:
+            return CTECSerializer.from_yaml(content)
+        else:
+            raise ValueError(f"Unsupported format: {format}")
+
+    @staticmethod
+    def detect_format(path: Union[str, Path]) -> OutputFormat:
+        """
+        Detect the format based on file extension.
+
+        Args:
+            path: Path to the file
+
+        Returns:
+            Detected output format
+
+        Raises:
+            ValueError: If the format cannot be determined
+        """
+        path = Path(path)
+        suffix = path.suffix.lower()
+        if suffix == ".toml":
+            return OutputFormat.TOML
+        elif suffix == ".json":
+            return OutputFormat.JSON
+        elif suffix in (".yaml", ".yml"):
+            return OutputFormat.YAML
+        else:
+            raise ValueError(
+                f"Cannot determine format from extension: {suffix}. "
+                "Use --format to specify explicitly."
+            )
+
+    @staticmethod
+    def read_file(path: Union[str, Path], format: OutputFormat = None) -> CTEC:
+        """
+        Read CTEC from a file.
+
+        Args:
+            path: Path to the file
+            format: Optional format override (auto-detected from extension if not provided)
+
+        Returns:
+            CTEC configuration
+        """
+        path = Path(path)
+        if format is None:
+            format = CTECSerializer.detect_format(path)
+        content = path.read_text()
+        return CTECSerializer.deserialize(content, format)
+
+    @staticmethod
+    def write_file(
+        ctec: CTEC, path: Union[str, Path], format: OutputFormat = None
+    ) -> None:
+        """
+        Write CTEC to a file.
+
+        Args:
+            ctec: The CTEC configuration to write
+            path: Path to the output file
+            format: Optional format override (auto-detected from extension if not provided)
+        """
+        path = Path(path)
+        if format is None:
+            format = CTECSerializer.detect_format(path)
+        content = CTECSerializer.serialize(ctec, format)
+        path.write_text(content)

--- a/console_cowboy/terminals/__init__.py
+++ b/console_cowboy/terminals/__init__.py
@@ -1,0 +1,30 @@
+"""
+Terminal emulator parsers and exporters.
+
+This module provides classes for reading and writing configuration files
+for various terminal emulators.
+"""
+
+from .base import TerminalAdapter, TerminalRegistry
+from .iterm2 import ITerm2Adapter
+from .ghostty import GhosttyAdapter
+from .alacritty import AlacrittyAdapter
+from .kitty import KittyAdapter
+from .wezterm import WeztermAdapter
+
+# Register all adapters
+TerminalRegistry.register(ITerm2Adapter)
+TerminalRegistry.register(GhosttyAdapter)
+TerminalRegistry.register(AlacrittyAdapter)
+TerminalRegistry.register(KittyAdapter)
+TerminalRegistry.register(WeztermAdapter)
+
+__all__ = [
+    "TerminalAdapter",
+    "TerminalRegistry",
+    "ITerm2Adapter",
+    "GhosttyAdapter",
+    "AlacrittyAdapter",
+    "KittyAdapter",
+    "WeztermAdapter",
+]

--- a/console_cowboy/terminals/alacritty.py
+++ b/console_cowboy/terminals/alacritty.py
@@ -1,0 +1,458 @@
+"""
+Alacritty configuration adapter.
+
+Alacritty uses YAML (versions < 0.13) or TOML (versions >= 0.13) format stored in
+~/.config/alacritty/alacritty.yml or ~/.config/alacritty/alacritty.toml
+"""
+
+from pathlib import Path
+from typing import Optional, Union
+
+import tomli
+import tomli_w
+import yaml
+
+from console_cowboy.ctec.schema import (
+    CTEC,
+    BehaviorConfig,
+    BellMode,
+    ColorScheme,
+    CursorConfig,
+    CursorStyle,
+    FontConfig,
+    KeyBinding,
+    WindowConfig,
+)
+from console_cowboy.utils.colors import normalize_color
+
+from .base import TerminalAdapter
+
+
+class AlacrittyAdapter(TerminalAdapter):
+    """
+    Adapter for Alacritty terminal emulator.
+
+    Supports both YAML (legacy) and TOML (modern) configuration formats.
+    """
+
+    name = "alacritty"
+    display_name = "Alacritty"
+    description = "Cross-platform, GPU-accelerated terminal emulator"
+    config_extensions = [".yml", ".yaml", ".toml"]
+    default_config_paths = [
+        ".config/alacritty/alacritty.toml",
+        ".config/alacritty/alacritty.yml",
+        ".alacritty.toml",
+        ".alacritty.yml",
+    ]
+
+    CURSOR_STYLE_MAP = {
+        "block": CursorStyle.BLOCK,
+        "beam": CursorStyle.BEAM,
+        "underline": CursorStyle.UNDERLINE,
+    }
+
+    CURSOR_STYLE_REVERSE_MAP = {v: k for k, v in CURSOR_STYLE_MAP.items()}
+
+    @classmethod
+    def _parse_color(cls, color_data: Union[str, dict]) -> Optional["Color"]:
+        """Parse a color from Alacritty format."""
+        if color_data is None:
+            return None
+        return normalize_color(color_data)
+
+    @classmethod
+    def _parse_colors(cls, colors: dict) -> ColorScheme:
+        """Parse Alacritty colors section."""
+        scheme = ColorScheme()
+
+        if "primary" in colors:
+            primary = colors["primary"]
+            if "foreground" in primary:
+                scheme.foreground = cls._parse_color(primary["foreground"])
+            if "background" in primary:
+                scheme.background = cls._parse_color(primary["background"])
+
+        if "cursor" in colors:
+            cursor = colors["cursor"]
+            if "cursor" in cursor:
+                scheme.cursor = cls._parse_color(cursor["cursor"])
+            if "text" in cursor:
+                scheme.cursor_text = cls._parse_color(cursor["text"])
+
+        if "selection" in colors:
+            selection = colors["selection"]
+            if "background" in selection:
+                scheme.selection = cls._parse_color(selection["background"])
+            if "text" in selection:
+                scheme.selection_text = cls._parse_color(selection["text"])
+
+        if "normal" in colors:
+            normal = colors["normal"]
+            color_map = {
+                "black": "black",
+                "red": "red",
+                "green": "green",
+                "yellow": "yellow",
+                "blue": "blue",
+                "magenta": "magenta",
+                "cyan": "cyan",
+                "white": "white",
+            }
+            for alac_key, ctec_key in color_map.items():
+                if alac_key in normal:
+                    setattr(scheme, ctec_key, cls._parse_color(normal[alac_key]))
+
+        if "bright" in colors:
+            bright = colors["bright"]
+            color_map = {
+                "black": "bright_black",
+                "red": "bright_red",
+                "green": "bright_green",
+                "yellow": "bright_yellow",
+                "blue": "bright_blue",
+                "magenta": "bright_magenta",
+                "cyan": "bright_cyan",
+                "white": "bright_white",
+            }
+            for alac_key, ctec_key in color_map.items():
+                if alac_key in bright:
+                    setattr(scheme, ctec_key, cls._parse_color(bright[alac_key]))
+
+        return scheme
+
+    @classmethod
+    def parse(
+        cls,
+        source: Union[str, Path],
+        *,
+        content: Optional[str] = None,
+    ) -> CTEC:
+        """Parse an Alacritty configuration file."""
+        ctec = CTEC(source_terminal="alacritty")
+
+        if content is None:
+            path = Path(source)
+            if not path.exists():
+                raise FileNotFoundError(f"Config file not found: {path}")
+            content = path.read_text()
+            is_toml = path.suffix == ".toml"
+        else:
+            # Try to detect format
+            is_toml = content.strip().startswith("[") or "=" in content.split("\n")[0]
+
+        if is_toml:
+            data = tomli.loads(content)
+        else:
+            data = yaml.safe_load(content) or {}
+
+        # Parse colors
+        if "colors" in data:
+            ctec.color_scheme = cls._parse_colors(data["colors"])
+
+        # Parse font
+        if "font" in data:
+            font_data = data["font"]
+            font = FontConfig()
+            if "normal" in font_data and "family" in font_data["normal"]:
+                font.family = font_data["normal"]["family"]
+            if "bold" in font_data and "family" in font_data["bold"]:
+                font.bold_font = font_data["bold"]["family"]
+            if "italic" in font_data and "family" in font_data["italic"]:
+                font.italic_font = font_data["italic"]["family"]
+            if "size" in font_data:
+                font.size = float(font_data["size"])
+            if "offset" in font_data and "y" in font_data["offset"]:
+                # Line height adjustment
+                font.line_height = 1.0 + font_data["offset"]["y"] / 10
+            ctec.font = font
+
+        # Parse cursor
+        if "cursor" in data:
+            cursor_data = data["cursor"]
+            cursor = CursorConfig()
+            if "style" in cursor_data:
+                style_data = cursor_data["style"]
+                if isinstance(style_data, str):
+                    cursor.style = cls.CURSOR_STYLE_MAP.get(style_data.lower(), CursorStyle.BLOCK)
+                elif isinstance(style_data, dict) and "shape" in style_data:
+                    cursor.style = cls.CURSOR_STYLE_MAP.get(
+                        style_data["shape"].lower(), CursorStyle.BLOCK
+                    )
+                    if "blinking" in style_data:
+                        cursor.blink = style_data["blinking"] not in ("Off", "Never", False)
+            if "blink_interval" in cursor_data:
+                cursor.blink_interval = cursor_data["blink_interval"]
+            ctec.cursor = cursor
+
+        # Parse window
+        if "window" in data:
+            window_data = data["window"]
+            window = WindowConfig()
+            if "dimensions" in window_data:
+                dims = window_data["dimensions"]
+                if "columns" in dims:
+                    window.columns = dims["columns"]
+                if "lines" in dims:
+                    window.rows = dims["lines"]
+            if "opacity" in window_data:
+                window.opacity = window_data["opacity"]
+            if "blur" in window_data:
+                window.blur = window_data["blur"] if isinstance(window_data["blur"], int) else 0
+            if "padding" in window_data:
+                padding = window_data["padding"]
+                if "x" in padding:
+                    window.padding_horizontal = padding["x"]
+                if "y" in padding:
+                    window.padding_vertical = padding["y"]
+            if "decorations" in window_data:
+                window.decorations = window_data["decorations"] not in ("None", "none", False)
+            if "startup_mode" in window_data:
+                window.startup_mode = window_data["startup_mode"].lower()
+            if "dynamic_title" in window_data:
+                window.dynamic_title = window_data["dynamic_title"]
+            ctec.window = window
+
+        # Parse shell/behavior
+        if "shell" in data:
+            behavior = BehaviorConfig()
+            shell_data = data["shell"]
+            if isinstance(shell_data, str):
+                behavior.shell = shell_data
+            elif isinstance(shell_data, dict) and "program" in shell_data:
+                behavior.shell = shell_data["program"]
+            ctec.behavior = behavior
+
+        if "scrolling" in data:
+            if ctec.behavior is None:
+                ctec.behavior = BehaviorConfig()
+            if "history" in data["scrolling"]:
+                ctec.behavior.scrollback_lines = data["scrolling"]["history"]
+
+        if "bell" in data:
+            if ctec.behavior is None:
+                ctec.behavior = BehaviorConfig()
+            bell_data = data["bell"]
+            if "duration" in bell_data:
+                if bell_data["duration"] == 0:
+                    ctec.behavior.bell_mode = BellMode.NONE
+                else:
+                    ctec.behavior.bell_mode = BellMode.VISUAL
+
+        if "mouse" in data:
+            if ctec.behavior is None:
+                ctec.behavior = BehaviorConfig()
+            mouse_data = data["mouse"]
+            # Alacritty doesn't have a single mouse enable toggle
+            # but we can infer from hide_when_typing
+            if "hide_when_typing" in mouse_data:
+                ctec.add_terminal_specific("alacritty", "mouse.hide_when_typing", mouse_data["hide_when_typing"])
+
+        if "selection" in data:
+            if ctec.behavior is None:
+                ctec.behavior = BehaviorConfig()
+            if "save_to_clipboard" in data["selection"]:
+                ctec.behavior.copy_on_select = data["selection"]["save_to_clipboard"]
+
+        # Parse key bindings
+        if "keyboard" in data and "bindings" in data["keyboard"]:
+            for binding in data["keyboard"]["bindings"]:
+                if "key" in binding and "action" in binding:
+                    kb = KeyBinding(
+                        action=binding["action"],
+                        key=binding["key"],
+                        mods=binding.get("mods", "").split("+") if binding.get("mods") else [],
+                    )
+                    ctec.key_bindings.append(kb)
+        # Legacy format
+        elif "key_bindings" in data:
+            for binding in data["key_bindings"]:
+                if "key" in binding and "action" in binding:
+                    kb = KeyBinding(
+                        action=binding["action"],
+                        key=binding["key"],
+                        mods=binding.get("mods", "").split("|") if binding.get("mods") else [],
+                    )
+                    ctec.key_bindings.append(kb)
+
+        # Store unrecognized top-level keys
+        recognized_keys = {"colors", "font", "cursor", "window", "shell", "scrolling", "bell", "mouse", "selection", "keyboard", "key_bindings"}
+        for key in data:
+            if key not in recognized_keys:
+                ctec.add_terminal_specific("alacritty", key, data[key])
+
+        return ctec
+
+    @classmethod
+    def export(cls, ctec: CTEC, use_toml: bool = True) -> str:
+        """
+        Export CTEC to Alacritty configuration format.
+
+        Args:
+            ctec: CTEC configuration to export
+            use_toml: If True, export as TOML; otherwise export as YAML
+
+        Returns:
+            Configuration string in the specified format
+        """
+        result = {}
+
+        # Export colors
+        if ctec.color_scheme:
+            scheme = ctec.color_scheme
+            colors = {}
+
+            primary = {}
+            if scheme.foreground:
+                primary["foreground"] = scheme.foreground.to_hex()
+            if scheme.background:
+                primary["background"] = scheme.background.to_hex()
+            if primary:
+                colors["primary"] = primary
+
+            cursor = {}
+            if scheme.cursor:
+                cursor["cursor"] = scheme.cursor.to_hex()
+            if scheme.cursor_text:
+                cursor["text"] = scheme.cursor_text.to_hex()
+            if cursor:
+                colors["cursor"] = cursor
+
+            selection = {}
+            if scheme.selection:
+                selection["background"] = scheme.selection.to_hex()
+            if scheme.selection_text:
+                selection["text"] = scheme.selection_text.to_hex()
+            if selection:
+                colors["selection"] = selection
+
+            normal = {}
+            for ctec_key, alac_key in [
+                ("black", "black"),
+                ("red", "red"),
+                ("green", "green"),
+                ("yellow", "yellow"),
+                ("blue", "blue"),
+                ("magenta", "magenta"),
+                ("cyan", "cyan"),
+                ("white", "white"),
+            ]:
+                color = getattr(scheme, ctec_key, None)
+                if color:
+                    normal[alac_key] = color.to_hex()
+            if normal:
+                colors["normal"] = normal
+
+            bright = {}
+            for ctec_key, alac_key in [
+                ("bright_black", "black"),
+                ("bright_red", "red"),
+                ("bright_green", "green"),
+                ("bright_yellow", "yellow"),
+                ("bright_blue", "blue"),
+                ("bright_magenta", "magenta"),
+                ("bright_cyan", "cyan"),
+                ("bright_white", "white"),
+            ]:
+                color = getattr(scheme, ctec_key, None)
+                if color:
+                    bright[alac_key] = color.to_hex()
+            if bright:
+                colors["bright"] = bright
+
+            if colors:
+                result["colors"] = colors
+
+        # Export font
+        if ctec.font:
+            font = {}
+            if ctec.font.family:
+                font["normal"] = {"family": ctec.font.family}
+            if ctec.font.bold_font:
+                font["bold"] = {"family": ctec.font.bold_font}
+            if ctec.font.italic_font:
+                font["italic"] = {"family": ctec.font.italic_font}
+            if ctec.font.size:
+                font["size"] = ctec.font.size
+            if ctec.font.line_height and ctec.font.line_height != 1.0:
+                font["offset"] = {"y": int((ctec.font.line_height - 1.0) * 10)}
+            if font:
+                result["font"] = font
+
+        # Export cursor
+        if ctec.cursor:
+            cursor = {}
+            style = {}
+            if ctec.cursor.style:
+                style["shape"] = cls.CURSOR_STYLE_REVERSE_MAP.get(ctec.cursor.style, "Block").capitalize()
+            if ctec.cursor.blink is not None:
+                style["blinking"] = "On" if ctec.cursor.blink else "Off"
+            if style:
+                cursor["style"] = style
+            if ctec.cursor.blink_interval:
+                cursor["blink_interval"] = ctec.cursor.blink_interval
+            if cursor:
+                result["cursor"] = cursor
+
+        # Export window
+        if ctec.window:
+            window = {}
+            if ctec.window.columns or ctec.window.rows:
+                dims = {}
+                if ctec.window.columns:
+                    dims["columns"] = ctec.window.columns
+                if ctec.window.rows:
+                    dims["lines"] = ctec.window.rows
+                window["dimensions"] = dims
+            if ctec.window.opacity is not None:
+                window["opacity"] = ctec.window.opacity
+            if ctec.window.blur:
+                window["blur"] = ctec.window.blur
+            if ctec.window.padding_horizontal is not None or ctec.window.padding_vertical is not None:
+                padding = {}
+                if ctec.window.padding_horizontal is not None:
+                    padding["x"] = ctec.window.padding_horizontal
+                if ctec.window.padding_vertical is not None:
+                    padding["y"] = ctec.window.padding_vertical
+                window["padding"] = padding
+            if ctec.window.decorations is not None:
+                window["decorations"] = "Full" if ctec.window.decorations else "None"
+            if ctec.window.startup_mode:
+                window["startup_mode"] = ctec.window.startup_mode.capitalize()
+            if ctec.window.dynamic_title is not None:
+                window["dynamic_title"] = ctec.window.dynamic_title
+            if window:
+                result["window"] = window
+
+        # Export behavior
+        if ctec.behavior:
+            if ctec.behavior.shell:
+                result["shell"] = {"program": ctec.behavior.shell}
+            if ctec.behavior.scrollback_lines is not None:
+                result["scrolling"] = {"history": ctec.behavior.scrollback_lines}
+            if ctec.behavior.bell_mode is not None:
+                if ctec.behavior.bell_mode == BellMode.NONE:
+                    result["bell"] = {"duration": 0}
+                else:
+                    result["bell"] = {"duration": 100}
+            if ctec.behavior.copy_on_select is not None:
+                result["selection"] = {"save_to_clipboard": ctec.behavior.copy_on_select}
+
+        # Export key bindings
+        if ctec.key_bindings:
+            bindings = []
+            for kb in ctec.key_bindings:
+                binding = {"key": kb.key, "action": kb.action}
+                if kb.mods:
+                    binding["mods"] = "+".join(kb.mods)
+                bindings.append(binding)
+            result["keyboard"] = {"bindings": bindings}
+
+        # Restore terminal-specific settings
+        for setting in ctec.get_terminal_specific("alacritty"):
+            result[setting.key] = setting.value
+
+        if use_toml:
+            return tomli_w.dumps(result)
+        else:
+            return yaml.dump(result, default_flow_style=False, sort_keys=False)

--- a/console_cowboy/terminals/base.py
+++ b/console_cowboy/terminals/base.py
@@ -1,0 +1,154 @@
+"""
+Base classes for terminal emulator adapters.
+
+Each terminal emulator adapter inherits from TerminalAdapter and implements
+methods to parse (import) and export configurations to/from CTEC format.
+"""
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Optional, Union
+
+from console_cowboy.ctec.schema import CTEC
+
+
+class TerminalAdapter(ABC):
+    """
+    Abstract base class for terminal emulator configuration adapters.
+
+    Each terminal emulator implementation should inherit from this class
+    and provide methods to:
+    - Parse the terminal's native config format into CTEC
+    - Export CTEC to the terminal's native config format
+    """
+
+    # Terminal identifier (lowercase, e.g., 'iterm2', 'ghostty')
+    name: str = ""
+
+    # Human-readable terminal name
+    display_name: str = ""
+
+    # Description of the terminal
+    description: str = ""
+
+    # File extensions for config files
+    config_extensions: list[str] = []
+
+    # Default config file paths (relative to home directory)
+    default_config_paths: list[str] = []
+
+    @classmethod
+    @abstractmethod
+    def parse(
+        cls,
+        source: Union[str, Path],
+        *,
+        content: Optional[str] = None,
+    ) -> CTEC:
+        """
+        Parse a terminal configuration file into CTEC format.
+
+        Args:
+            source: Path to the configuration file, or identifier for content
+            content: Optional string content (if provided, source is used as identifier)
+
+        Returns:
+            CTEC configuration
+
+        Raises:
+            FileNotFoundError: If the source file doesn't exist
+            ValueError: If the configuration cannot be parsed
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def export(cls, ctec: CTEC) -> str:
+        """
+        Export CTEC configuration to the terminal's native format.
+
+        Args:
+            ctec: CTEC configuration to export
+
+        Returns:
+            String in the terminal's native configuration format
+        """
+        pass
+
+    @classmethod
+    def get_default_config_path(cls) -> Optional[Path]:
+        """
+        Get the default configuration file path for this terminal.
+
+        Returns:
+            Path to the default config file, or None if not found
+        """
+        home = Path.home()
+        for path in cls.default_config_paths:
+            full_path = home / path
+            if full_path.exists():
+                return full_path
+        return None
+
+    @classmethod
+    def write_config(cls, ctec: CTEC, path: Union[str, Path]) -> None:
+        """
+        Export and write CTEC configuration to a file.
+
+        Args:
+            ctec: CTEC configuration to export
+            path: Path to write the configuration to
+        """
+        content = cls.export(ctec)
+        Path(path).write_text(content)
+
+
+class TerminalRegistry:
+    """
+    Registry of available terminal adapters.
+    """
+
+    _adapters: dict[str, type[TerminalAdapter]] = {}
+
+    @classmethod
+    def register(cls, adapter: type[TerminalAdapter]) -> None:
+        """
+        Register a terminal adapter.
+
+        Args:
+            adapter: Terminal adapter class to register
+        """
+        cls._adapters[adapter.name] = adapter
+
+    @classmethod
+    def get(cls, name: str) -> Optional[type[TerminalAdapter]]:
+        """
+        Get a terminal adapter by name.
+
+        Args:
+            name: Terminal name (case-insensitive)
+
+        Returns:
+            Terminal adapter class, or None if not found
+        """
+        return cls._adapters.get(name.lower())
+
+    @classmethod
+    def list_terminals(cls) -> list[type[TerminalAdapter]]:
+        """
+        List all registered terminal adapters.
+
+        Returns:
+            List of terminal adapter classes
+        """
+        return list(cls._adapters.values())
+
+    @classmethod
+    def get_names(cls) -> list[str]:
+        """
+        Get names of all registered terminals.
+
+        Returns:
+            List of terminal names
+        """
+        return list(cls._adapters.keys())

--- a/console_cowboy/terminals/iterm2.py
+++ b/console_cowboy/terminals/iterm2.py
@@ -1,0 +1,369 @@
+"""
+iTerm2 configuration adapter.
+
+iTerm2 uses a macOS plist format for its configuration, stored in
+~/Library/Preferences/com.googlecode.iterm2.plist
+
+Color schemes can also be stored as separate .itermcolors files.
+"""
+
+import plistlib
+from pathlib import Path
+from typing import Optional, Union
+
+from console_cowboy.ctec.schema import (
+    CTEC,
+    BehaviorConfig,
+    BellMode,
+    Color,
+    ColorScheme,
+    CursorConfig,
+    CursorStyle,
+    FontConfig,
+    KeyBinding,
+    Profile,
+    WindowConfig,
+)
+from console_cowboy.utils.colors import color_to_float_tuple, float_tuple_to_color
+
+from .base import TerminalAdapter
+
+
+class ITerm2Adapter(TerminalAdapter):
+    """
+    Adapter for iTerm2 terminal emulator.
+
+    Supports parsing:
+    - Full iTerm2 plist configuration
+    - .itermcolors color scheme files
+
+    Note: iTerm2 uses plist format with colors stored as floating point
+    RGB values (0.0-1.0).
+    """
+
+    name = "iterm2"
+    display_name = "iTerm2"
+    description = "macOS terminal emulator with extensive customization options"
+    config_extensions = [".plist", ".itermcolors"]
+    default_config_paths = [
+        "Library/Preferences/com.googlecode.iterm2.plist",
+    ]
+
+    # Mapping of iTerm2 cursor styles to CTEC
+    CURSOR_STYLE_MAP = {
+        0: CursorStyle.UNDERLINE,
+        1: CursorStyle.BLOCK,
+        2: CursorStyle.BEAM,
+    }
+
+    CURSOR_STYLE_REVERSE_MAP = {v: k for k, v in CURSOR_STYLE_MAP.items()}
+
+    # Color key mappings from iTerm2 to CTEC
+    COLOR_KEY_MAP = {
+        "Foreground Color": "foreground",
+        "Background Color": "background",
+        "Cursor Color": "cursor",
+        "Cursor Text Color": "cursor_text",
+        "Selection Color": "selection",
+        "Selected Text Color": "selection_text",
+        "Ansi 0 Color": "black",
+        "Ansi 1 Color": "red",
+        "Ansi 2 Color": "green",
+        "Ansi 3 Color": "yellow",
+        "Ansi 4 Color": "blue",
+        "Ansi 5 Color": "magenta",
+        "Ansi 6 Color": "cyan",
+        "Ansi 7 Color": "white",
+        "Ansi 8 Color": "bright_black",
+        "Ansi 9 Color": "bright_red",
+        "Ansi 10 Color": "bright_green",
+        "Ansi 11 Color": "bright_yellow",
+        "Ansi 12 Color": "bright_blue",
+        "Ansi 13 Color": "bright_magenta",
+        "Ansi 14 Color": "bright_cyan",
+        "Ansi 15 Color": "bright_white",
+    }
+
+    COLOR_KEY_REVERSE_MAP = {v: k for k, v in COLOR_KEY_MAP.items()}
+
+    @classmethod
+    def _parse_iterm_color(cls, color_dict: dict) -> Color:
+        """Parse an iTerm2 color dictionary to a Color object."""
+        # iTerm2 uses "Color Space" and RGB component keys
+        r = color_dict.get("Red Component", 0.0)
+        g = color_dict.get("Green Component", 0.0)
+        b = color_dict.get("Blue Component", 0.0)
+        return float_tuple_to_color((r, g, b))
+
+    @classmethod
+    def _export_color(cls, color: Color) -> dict:
+        """Export a Color to iTerm2 color dictionary format."""
+        r, g, b = color_to_float_tuple(color)
+        return {
+            "Color Space": "sRGB",
+            "Red Component": r,
+            "Green Component": g,
+            "Blue Component": b,
+        }
+
+    @classmethod
+    def _parse_color_scheme(cls, profile: dict) -> ColorScheme:
+        """Parse color settings from an iTerm2 profile."""
+        scheme = ColorScheme()
+        for iterm_key, ctec_key in cls.COLOR_KEY_MAP.items():
+            if iterm_key in profile:
+                color = cls._parse_iterm_color(profile[iterm_key])
+                setattr(scheme, ctec_key, color)
+        return scheme
+
+    @classmethod
+    def _parse_profile(cls, profile_data: dict, ctec: CTEC) -> Profile:
+        """Parse an iTerm2 profile into a CTEC Profile."""
+        name = profile_data.get("Name", "Default")
+        profile = Profile(name=name)
+
+        # Parse color scheme
+        profile.color_scheme = cls._parse_color_scheme(profile_data)
+
+        # Parse font configuration
+        if "Normal Font" in profile_data:
+            font_str = profile_data["Normal Font"]
+            # iTerm2 font format: "FontName Size"
+            parts = font_str.rsplit(" ", 1)
+            if len(parts) == 2:
+                profile.font = FontConfig(
+                    family=parts[0],
+                    size=float(parts[1]) if parts[1].replace(".", "").isdigit() else None,
+                )
+            else:
+                profile.font = FontConfig(family=font_str)
+
+        # Parse cursor configuration
+        cursor_config = CursorConfig()
+        if "Cursor Type" in profile_data:
+            cursor_type = profile_data["Cursor Type"]
+            cursor_config.style = cls.CURSOR_STYLE_MAP.get(cursor_type, CursorStyle.BLOCK)
+        if "Blinking Cursor" in profile_data:
+            cursor_config.blink = profile_data["Blinking Cursor"]
+        profile.cursor = cursor_config
+
+        # Parse behavior configuration
+        behavior = BehaviorConfig()
+        if "Command" in profile_data:
+            behavior.shell = profile_data["Command"]
+        if "Working Directory" in profile_data:
+            behavior.working_directory = profile_data["Working Directory"]
+        if "Scrollback Lines" in profile_data:
+            behavior.scrollback_lines = profile_data["Scrollback Lines"]
+        if "Silence Bell" in profile_data:
+            if profile_data["Silence Bell"]:
+                behavior.bell_mode = BellMode.NONE
+            elif profile_data.get("Visual Bell", False):
+                behavior.bell_mode = BellMode.VISUAL
+            else:
+                behavior.bell_mode = BellMode.AUDIBLE
+        profile.behavior = behavior
+
+        # Store iTerm2-specific settings
+        specific_keys = [
+            "Unlimited Scrollback",
+            "Use Bold Font",
+            "Use Italic Font",
+            "ASCII Anti Aliased",
+            "Non-ASCII Anti Aliased",
+            "Ambiguous Double Width",
+            "Horizontal Spacing",
+            "Vertical Spacing",
+            "Use Non-ASCII Font",
+            "Minimum Contrast",
+            "Draw Powerline Glyphs",
+        ]
+        for key in specific_keys:
+            if key in profile_data:
+                ctec.add_terminal_specific("iterm2", f"profile.{name}.{key}", profile_data[key])
+
+        return profile
+
+    @classmethod
+    def parse(
+        cls,
+        source: Union[str, Path],
+        *,
+        content: Optional[str] = None,
+    ) -> CTEC:
+        """
+        Parse an iTerm2 configuration file.
+
+        Supports both full plist configs and .itermcolors files.
+        """
+        ctec = CTEC(source_terminal="iterm2")
+
+        if content is not None:
+            data = plistlib.loads(content.encode())
+        else:
+            path = Path(source)
+            if not path.exists():
+                raise FileNotFoundError(f"Config file not found: {path}")
+            with open(path, "rb") as f:
+                data = plistlib.load(f)
+
+        # Check if this is a color scheme file (.itermcolors)
+        if "Ansi 0 Color" in data or "Foreground Color" in data:
+            # This is a color scheme file
+            ctec.color_scheme = cls._parse_color_scheme(data)
+            return ctec
+
+        # Full iTerm2 config
+        if "New Bookmarks" in data:
+            # Parse profiles
+            for i, profile_data in enumerate(data["New Bookmarks"]):
+                profile = cls._parse_profile(profile_data, ctec)
+                if i == 0 or profile_data.get("Default Bookmark", "No") == "Yes":
+                    profile.is_default = True
+                ctec.profiles.append(profile)
+
+            # Set global settings from default profile if available
+            if ctec.profiles:
+                default_profile = next(
+                    (p for p in ctec.profiles if p.is_default), ctec.profiles[0]
+                )
+                ctec.color_scheme = default_profile.color_scheme
+                ctec.font = default_profile.font
+                ctec.cursor = default_profile.cursor
+                ctec.behavior = default_profile.behavior
+
+        # Parse window configuration
+        window = WindowConfig()
+        if "Default Bookmark Window Width" in data:
+            window.columns = data["Default Bookmark Window Width"]
+        if "Default Bookmark Window Height" in data:
+            window.rows = data["Default Bookmark Window Height"]
+        if window.columns or window.rows:
+            ctec.window = window
+
+        # Parse global settings
+        global_specific_keys = [
+            "TabStyleWithAutomaticOption",
+            "HideTab",
+            "HideMenuBarInFullscreen",
+            "SplitPaneDimmingAmount",
+            "UseBorder",
+            "HideScrollbar",
+            "PromptOnQuit",
+            "OnlyWhenMoreTabs",
+        ]
+        for key in global_specific_keys:
+            if key in data:
+                ctec.add_terminal_specific("iterm2", key, data[key])
+
+        return ctec
+
+    @classmethod
+    def _export_profile(cls, profile: Profile, ctec: CTEC) -> dict:
+        """Export a CTEC Profile to iTerm2 profile format."""
+        result = {"Name": profile.name, "Guid": profile.name.lower().replace(" ", "-")}
+
+        # Export colors
+        color_scheme = profile.color_scheme or ctec.color_scheme
+        if color_scheme:
+            for ctec_key, iterm_key in cls.COLOR_KEY_REVERSE_MAP.items():
+                color = getattr(color_scheme, ctec_key, None)
+                if color:
+                    result[iterm_key] = cls._export_color(color)
+
+        # Export font
+        font = profile.font or ctec.font
+        if font and font.family:
+            size = font.size or 12
+            result["Normal Font"] = f"{font.family} {size}"
+
+        # Export cursor
+        cursor = profile.cursor or ctec.cursor
+        if cursor:
+            if cursor.style:
+                result["Cursor Type"] = cls.CURSOR_STYLE_REVERSE_MAP.get(cursor.style, 1)
+            if cursor.blink is not None:
+                result["Blinking Cursor"] = cursor.blink
+
+        # Export behavior
+        behavior = profile.behavior or ctec.behavior
+        if behavior:
+            if behavior.shell:
+                result["Command"] = behavior.shell
+                result["Custom Command"] = "Yes"
+            if behavior.working_directory:
+                result["Working Directory"] = behavior.working_directory
+                result["Custom Directory"] = "Yes"
+            if behavior.scrollback_lines is not None:
+                result["Scrollback Lines"] = behavior.scrollback_lines
+            if behavior.bell_mode is not None:
+                result["Silence Bell"] = behavior.bell_mode == BellMode.NONE
+                result["Visual Bell"] = behavior.bell_mode == BellMode.VISUAL
+
+        # Restore terminal-specific settings
+        for setting in ctec.get_terminal_specific("iterm2"):
+            if setting.key.startswith(f"profile.{profile.name}."):
+                actual_key = setting.key.split(".", 2)[2]
+                result[actual_key] = setting.value
+
+        return result
+
+    @classmethod
+    def export(cls, ctec: CTEC) -> str:
+        """
+        Export CTEC to iTerm2 plist format.
+
+        Returns a plist XML string that can be saved to a file.
+        """
+        result = {}
+
+        # Export profiles
+        profiles = []
+        if ctec.profiles:
+            for profile in ctec.profiles:
+                profiles.append(cls._export_profile(profile, ctec))
+        else:
+            # Create a default profile from global settings
+            default_profile = Profile(
+                name="Default",
+                color_scheme=ctec.color_scheme,
+                font=ctec.font,
+                cursor=ctec.cursor,
+                behavior=ctec.behavior,
+                is_default=True,
+            )
+            profiles.append(cls._export_profile(default_profile, ctec))
+
+        result["New Bookmarks"] = profiles
+
+        # Export window configuration
+        if ctec.window:
+            if ctec.window.columns:
+                result["Default Bookmark Window Width"] = ctec.window.columns
+            if ctec.window.rows:
+                result["Default Bookmark Window Height"] = ctec.window.rows
+
+        # Restore terminal-specific global settings
+        for setting in ctec.get_terminal_specific("iterm2"):
+            if not setting.key.startswith("profile."):
+                result[setting.key] = setting.value
+
+        return plistlib.dumps(result).decode()
+
+    @classmethod
+    def export_color_scheme(cls, color_scheme: ColorScheme) -> str:
+        """
+        Export a ColorScheme to .itermcolors format.
+
+        Args:
+            color_scheme: Color scheme to export
+
+        Returns:
+            Plist XML string for .itermcolors file
+        """
+        result = {}
+        for ctec_key, iterm_key in cls.COLOR_KEY_REVERSE_MAP.items():
+            color = getattr(color_scheme, ctec_key, None)
+            if color:
+                result[iterm_key] = cls._export_color(color)
+        return plistlib.dumps(result).decode()

--- a/console_cowboy/terminals/wezterm.py
+++ b/console_cowboy/terminals/wezterm.py
@@ -1,0 +1,490 @@
+"""
+Wezterm configuration adapter.
+
+Wezterm uses Lua for configuration, stored in ~/.wezterm.lua or
+~/.config/wezterm/wezterm.lua
+
+This adapter generates and parses a simplified subset of Wezterm's
+Lua configuration format.
+"""
+
+import re
+from pathlib import Path
+from typing import Optional, Union
+
+from console_cowboy.ctec.schema import (
+    CTEC,
+    BehaviorConfig,
+    BellMode,
+    ColorScheme,
+    CursorConfig,
+    CursorStyle,
+    FontConfig,
+    KeyBinding,
+    WindowConfig,
+)
+from console_cowboy.utils.colors import normalize_color
+
+from .base import TerminalAdapter
+
+
+class WeztermAdapter(TerminalAdapter):
+    """
+    Adapter for Wezterm terminal emulator.
+
+    Wezterm uses Lua configuration which is complex to fully parse.
+    This adapter handles common configuration patterns and provides
+    best-effort parsing of Lua configs.
+    """
+
+    name = "wezterm"
+    display_name = "Wezterm"
+    description = "GPU-accelerated terminal emulator with Lua configuration"
+    config_extensions = [".lua"]
+    default_config_paths = [
+        ".wezterm.lua",
+        ".config/wezterm/wezterm.lua",
+    ]
+
+    CURSOR_STYLE_MAP = {
+        "SteadyBlock": CursorStyle.BLOCK,
+        "BlinkingBlock": CursorStyle.BLOCK,
+        "SteadyBar": CursorStyle.BEAM,
+        "BlinkingBar": CursorStyle.BEAM,
+        "SteadyUnderline": CursorStyle.UNDERLINE,
+        "BlinkingUnderline": CursorStyle.UNDERLINE,
+    }
+
+    @classmethod
+    def _extract_lua_value(cls, content: str, key: str) -> Optional[str]:
+        """Extract a simple value from Lua config (config.key = value)."""
+        # Match patterns like: config.font_size = 12
+        pattern = rf'config\.{re.escape(key)}\s*=\s*([^\n,}}]+)'
+        match = re.search(pattern, content)
+        if match:
+            value = match.group(1).strip()
+            # Remove quotes if present
+            if (value.startswith('"') and value.endswith('"')) or (
+                value.startswith("'") and value.endswith("'")
+            ):
+                value = value[1:-1]
+            return value
+        return None
+
+    @classmethod
+    def _extract_lua_table(cls, content: str, key: str) -> Optional[str]:
+        """Extract a table value from Lua config."""
+        # Match patterns like: config.colors = { ... }
+        pattern = rf'config\.{re.escape(key)}\s*=\s*\{{'
+        match = re.search(pattern, content)
+        if match:
+            start = match.end() - 1
+            depth = 0
+            for i, char in enumerate(content[start:]):
+                if char == "{":
+                    depth += 1
+                elif char == "}":
+                    depth -= 1
+                    if depth == 0:
+                        return content[start : start + i + 1]
+        return None
+
+    @classmethod
+    def _parse_lua_color(cls, color_str: str) -> Optional["Color"]:
+        """Parse a color from Lua format."""
+        color_str = color_str.strip().strip("'\"")
+        if color_str.lower() == "none":
+            return None
+        try:
+            return normalize_color(color_str)
+        except ValueError:
+            return None
+
+    @classmethod
+    def _parse_colors_table(cls, table_str: str) -> ColorScheme:
+        """Parse a Wezterm colors table."""
+        scheme = ColorScheme()
+
+        # Parse simple color assignments
+        color_patterns = {
+            "foreground": "foreground",
+            "background": "background",
+            "cursor_fg": "cursor_text",
+            "cursor_bg": "cursor",
+            "selection_fg": "selection_text",
+            "selection_bg": "selection",
+        }
+
+        for wez_key, ctec_key in color_patterns.items():
+            pattern = rf'{wez_key}\s*=\s*["\']([^"\']+)["\']'
+            match = re.search(pattern, table_str)
+            if match:
+                color = cls._parse_lua_color(match.group(1))
+                if color:
+                    setattr(scheme, ctec_key, color)
+
+        # Parse ansi colors array
+        ansi_pattern = r'ansi\s*=\s*\{([^}]+)\}'
+        ansi_match = re.search(ansi_pattern, table_str)
+        if ansi_match:
+            colors_str = ansi_match.group(1)
+            colors = re.findall(r'["\']([^"\']+)["\']', colors_str)
+            ansi_names = ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"]
+            for i, (name, color_str) in enumerate(zip(ansi_names, colors)):
+                color = cls._parse_lua_color(color_str)
+                if color:
+                    setattr(scheme, name, color)
+
+        # Parse bright/brights colors array
+        brights_pattern = r'brights\s*=\s*\{([^}]+)\}'
+        brights_match = re.search(brights_pattern, table_str)
+        if brights_match:
+            colors_str = brights_match.group(1)
+            colors = re.findall(r'["\']([^"\']+)["\']', colors_str)
+            bright_names = [
+                "bright_black",
+                "bright_red",
+                "bright_green",
+                "bright_yellow",
+                "bright_blue",
+                "bright_magenta",
+                "bright_cyan",
+                "bright_white",
+            ]
+            for i, (name, color_str) in enumerate(zip(bright_names, colors)):
+                color = cls._parse_lua_color(color_str)
+                if color:
+                    setattr(scheme, name, color)
+
+        return scheme
+
+    @classmethod
+    def parse(
+        cls,
+        source: Union[str, Path],
+        *,
+        content: Optional[str] = None,
+    ) -> CTEC:
+        """Parse a Wezterm configuration file."""
+        ctec = CTEC(source_terminal="wezterm")
+
+        if content is None:
+            path = Path(source)
+            if not path.exists():
+                raise FileNotFoundError(f"Config file not found: {path}")
+            content = path.read_text()
+
+        ctec.add_warning(
+            "Wezterm uses Lua configuration. "
+            "Some settings may not be fully parsed."
+        )
+
+        # Parse colors
+        colors_table = cls._extract_lua_table(content, "colors")
+        if colors_table:
+            ctec.color_scheme = cls._parse_colors_table(colors_table)
+
+        # Parse font
+        font = FontConfig()
+        font_family = cls._extract_lua_value(content, "font")
+        if font_family:
+            # Extract font family from wezterm.font("Family")
+            family_match = re.search(r'wezterm\.font\s*\(\s*["\']([^"\']+)["\']', font_family)
+            if family_match:
+                font.family = family_match.group(1)
+
+        font_size = cls._extract_lua_value(content, "font_size")
+        if font_size:
+            try:
+                font.size = float(font_size)
+            except ValueError:
+                ctec.add_warning(f"Invalid font_size: {font_size}")
+
+        line_height = cls._extract_lua_value(content, "line_height")
+        if line_height:
+            try:
+                font.line_height = float(line_height)
+            except ValueError:
+                ctec.add_warning(f"Invalid line_height: {line_height}")
+
+        if font.family or font.size:
+            ctec.font = font
+
+        # Parse cursor
+        cursor = CursorConfig()
+        cursor_style = cls._extract_lua_value(content, "default_cursor_style")
+        if cursor_style:
+            cursor_style = cursor_style.strip("'\"")
+            if cursor_style in cls.CURSOR_STYLE_MAP:
+                cursor.style = cls.CURSOR_STYLE_MAP[cursor_style]
+                cursor.blink = "Blinking" in cursor_style
+
+        cursor_blink = cls._extract_lua_value(content, "cursor_blink_rate")
+        if cursor_blink:
+            try:
+                rate = int(cursor_blink)
+                cursor.blink = rate > 0
+                if rate > 0:
+                    cursor.blink_interval = rate
+            except ValueError:
+                pass
+
+        if cursor.style or cursor.blink is not None:
+            ctec.cursor = cursor
+
+        # Parse window
+        window = WindowConfig()
+
+        # Initial cols/rows
+        initial_cols = cls._extract_lua_value(content, "initial_cols")
+        if initial_cols:
+            try:
+                window.columns = int(initial_cols)
+            except ValueError:
+                pass
+
+        initial_rows = cls._extract_lua_value(content, "initial_rows")
+        if initial_rows:
+            try:
+                window.rows = int(initial_rows)
+            except ValueError:
+                pass
+
+        # Window opacity
+        opacity = cls._extract_lua_value(content, "window_background_opacity")
+        if opacity:
+            try:
+                window.opacity = float(opacity)
+            except ValueError:
+                pass
+
+        # Window padding
+        padding_table = cls._extract_lua_table(content, "window_padding")
+        if padding_table:
+            left_match = re.search(r'left\s*=\s*(\d+)', padding_table)
+            top_match = re.search(r'top\s*=\s*(\d+)', padding_table)
+            if left_match:
+                window.padding_horizontal = int(left_match.group(1))
+            if top_match:
+                window.padding_vertical = int(top_match.group(1))
+
+        # Window decorations
+        decorations = cls._extract_lua_value(content, "window_decorations")
+        if decorations:
+            decorations = decorations.strip("'\"")
+            window.decorations = decorations.upper() not in ("NONE", "RESIZE")
+
+        if window.columns or window.rows or window.opacity is not None:
+            ctec.window = window
+
+        # Parse behavior
+        behavior = BehaviorConfig()
+
+        # Default program/shell
+        default_prog = cls._extract_lua_value(content, "default_prog")
+        if default_prog:
+            # Extract from array like { '/bin/bash' }
+            prog_match = re.search(r'["\']([^"\']+)["\']', default_prog)
+            if prog_match:
+                behavior.shell = prog_match.group(1)
+
+        scrollback = cls._extract_lua_value(content, "scrollback_lines")
+        if scrollback:
+            try:
+                behavior.scrollback_lines = int(scrollback)
+            except ValueError:
+                pass
+
+        # Bell
+        audible_bell = cls._extract_lua_value(content, "audible_bell")
+        if audible_bell:
+            audible_bell = audible_bell.strip("'\"")
+            if audible_bell == "Disabled":
+                behavior.bell_mode = BellMode.NONE
+            else:
+                behavior.bell_mode = BellMode.AUDIBLE
+
+        visual_bell = cls._extract_lua_table(content, "visual_bell")
+        if visual_bell and "duration_ms" in visual_bell:
+            duration_match = re.search(r'duration_ms\s*=\s*(\d+)', visual_bell)
+            if duration_match and int(duration_match.group(1)) > 0:
+                behavior.bell_mode = BellMode.VISUAL
+
+        if behavior.shell or behavior.scrollback_lines or behavior.bell_mode:
+            ctec.behavior = behavior
+
+        # Parse key bindings
+        keys_table = cls._extract_lua_table(content, "keys")
+        if keys_table:
+            # Match patterns like { key = "v", mods = "CTRL", action = ... }
+            binding_pattern = r'\{\s*key\s*=\s*["\']([^"\']+)["\']\s*,\s*mods\s*=\s*["\']([^"\']+)["\']\s*,\s*action\s*=\s*([^}]+)\}'
+            for match in re.finditer(binding_pattern, keys_table):
+                key = match.group(1)
+                mods = match.group(2).split("|")
+                action = match.group(3).strip()
+                # Simplify action for storage
+                action_match = re.search(r'act\.(\w+)', action)
+                if action_match:
+                    action = action_match.group(1)
+                ctec.key_bindings.append(KeyBinding(action=action, key=key, mods=mods))
+
+        return ctec
+
+    @classmethod
+    def export(cls, ctec: CTEC) -> str:
+        """Export CTEC to Wezterm Lua configuration format."""
+        lines = [
+            "-- Wezterm configuration",
+            "-- Generated by console-cowboy",
+            "",
+            "local wezterm = require 'wezterm'",
+            "local config = wezterm.config_builder()",
+            "",
+        ]
+
+        # Export colors
+        if ctec.color_scheme:
+            scheme = ctec.color_scheme
+            lines.append("-- Colors")
+            lines.append("config.colors = {")
+
+            if scheme.foreground:
+                lines.append(f'  foreground = "{scheme.foreground.to_hex()}",')
+            if scheme.background:
+                lines.append(f'  background = "{scheme.background.to_hex()}",')
+            if scheme.cursor:
+                lines.append(f'  cursor_bg = "{scheme.cursor.to_hex()}",')
+            if scheme.cursor_text:
+                lines.append(f'  cursor_fg = "{scheme.cursor_text.to_hex()}",')
+            if scheme.selection:
+                lines.append(f'  selection_bg = "{scheme.selection.to_hex()}",')
+            if scheme.selection_text:
+                lines.append(f'  selection_fg = "{scheme.selection_text.to_hex()}",')
+
+            # ANSI colors
+            ansi_colors = []
+            for attr in ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"]:
+                color = getattr(scheme, attr, None)
+                if color:
+                    ansi_colors.append(f'"{color.to_hex()}"')
+            if ansi_colors:
+                lines.append(f'  ansi = {{ {", ".join(ansi_colors)} }},')
+
+            # Bright colors
+            bright_colors = []
+            for attr in [
+                "bright_black",
+                "bright_red",
+                "bright_green",
+                "bright_yellow",
+                "bright_blue",
+                "bright_magenta",
+                "bright_cyan",
+                "bright_white",
+            ]:
+                color = getattr(scheme, attr, None)
+                if color:
+                    bright_colors.append(f'"{color.to_hex()}"')
+            if bright_colors:
+                lines.append(f'  brights = {{ {", ".join(bright_colors)} }},')
+
+            lines.append("}")
+            lines.append("")
+
+        # Export font
+        if ctec.font:
+            lines.append("-- Font")
+            if ctec.font.family:
+                lines.append(f'config.font = wezterm.font("{ctec.font.family}")')
+            if ctec.font.size:
+                lines.append(f"config.font_size = {ctec.font.size}")
+            if ctec.font.line_height:
+                lines.append(f"config.line_height = {ctec.font.line_height}")
+            lines.append("")
+
+        # Export cursor
+        if ctec.cursor:
+            lines.append("-- Cursor")
+            if ctec.cursor.style:
+                style_map = {
+                    CursorStyle.BLOCK: ("SteadyBlock", "BlinkingBlock"),
+                    CursorStyle.BEAM: ("SteadyBar", "BlinkingBar"),
+                    CursorStyle.UNDERLINE: ("SteadyUnderline", "BlinkingUnderline"),
+                }
+                styles = style_map.get(ctec.cursor.style, ("SteadyBlock", "BlinkingBlock"))
+                style = styles[1] if ctec.cursor.blink else styles[0]
+                lines.append(f'config.default_cursor_style = "{style}"')
+            if ctec.cursor.blink_interval:
+                lines.append(f"config.cursor_blink_rate = {ctec.cursor.blink_interval}")
+            lines.append("")
+
+        # Export window
+        if ctec.window:
+            lines.append("-- Window")
+            if ctec.window.columns:
+                lines.append(f"config.initial_cols = {ctec.window.columns}")
+            if ctec.window.rows:
+                lines.append(f"config.initial_rows = {ctec.window.rows}")
+            if ctec.window.opacity is not None:
+                lines.append(f"config.window_background_opacity = {ctec.window.opacity}")
+            if ctec.window.padding_horizontal is not None or ctec.window.padding_vertical is not None:
+                h = ctec.window.padding_horizontal or 0
+                v = ctec.window.padding_vertical or 0
+                lines.append("config.window_padding = {")
+                lines.append(f"  left = {h},")
+                lines.append(f"  right = {h},")
+                lines.append(f"  top = {v},")
+                lines.append(f"  bottom = {v},")
+                lines.append("}")
+            if ctec.window.decorations is not None:
+                val = "FULL" if ctec.window.decorations else "NONE"
+                lines.append(f'config.window_decorations = "{val}"')
+            lines.append("")
+
+        # Export behavior
+        if ctec.behavior:
+            lines.append("-- Behavior")
+            if ctec.behavior.shell:
+                lines.append(f'config.default_prog = {{ "{ctec.behavior.shell}" }}')
+            if ctec.behavior.scrollback_lines is not None:
+                lines.append(f"config.scrollback_lines = {ctec.behavior.scrollback_lines}")
+            if ctec.behavior.bell_mode is not None:
+                if ctec.behavior.bell_mode == BellMode.NONE:
+                    lines.append('config.audible_bell = "Disabled"')
+                elif ctec.behavior.bell_mode == BellMode.VISUAL:
+                    lines.append('config.audible_bell = "Disabled"')
+                    lines.append("config.visual_bell = {")
+                    lines.append('  fade_in_function = "EaseIn",')
+                    lines.append("  fade_in_duration_ms = 50,")
+                    lines.append('  fade_out_function = "EaseOut",')
+                    lines.append("  fade_out_duration_ms = 50,")
+                    lines.append("}")
+                else:
+                    lines.append('config.audible_bell = "SystemBeep"')
+            lines.append("")
+
+        # Export key bindings
+        if ctec.key_bindings:
+            lines.append("-- Key bindings")
+            lines.append("config.keys = {")
+            for kb in ctec.key_bindings:
+                mods = "|".join(kb.mods) if kb.mods else "NONE"
+                lines.append(f'  {{ key = "{kb.key}", mods = "{mods}", action = wezterm.action.{kb.action} }},')
+            lines.append("}")
+            lines.append("")
+
+        # Restore terminal-specific settings
+        wezterm_specific = ctec.get_terminal_specific("wezterm")
+        if wezterm_specific:
+            lines.append("-- Terminal-specific settings")
+            for setting in wezterm_specific:
+                value = setting.value
+                if isinstance(value, str):
+                    value = f'"{value}"'
+                elif isinstance(value, bool):
+                    value = str(value).lower()
+                lines.append(f"config.{setting.key} = {value}")
+            lines.append("")
+
+        lines.append("return config")
+        return "\n".join(lines)

--- a/console_cowboy/utils/__init__.py
+++ b/console_cowboy/utils/__init__.py
@@ -1,0 +1,7 @@
+"""
+Utility modules for console-cowboy.
+"""
+
+from .colors import normalize_color, color_to_float_tuple, float_tuple_to_color
+
+__all__ = ["normalize_color", "color_to_float_tuple", "float_tuple_to_color"]

--- a/console_cowboy/utils/colors.py
+++ b/console_cowboy/utils/colors.py
@@ -1,0 +1,93 @@
+"""
+Color conversion utilities for terminal configurations.
+
+Different terminal emulators use different color representations:
+- Hex strings: '#ff0000', 'ff0000'
+- RGB tuples: (255, 0, 0)
+- Float tuples: (1.0, 0.0, 0.0)
+- Named colors: 'red', 'blue'
+
+This module provides utilities for converting between these formats.
+"""
+
+from typing import Tuple, Union
+
+from console_cowboy.ctec.schema import Color
+
+
+def normalize_color(value: Union[str, dict, tuple, list, Color]) -> Color:
+    """
+    Normalize a color value from various formats to a Color object.
+
+    Args:
+        value: Color in various formats:
+            - Hex string: '#ff0000' or 'ff0000'
+            - Dict with r,g,b keys: {'r': 255, 'g': 0, 'b': 0}
+            - Tuple/list of ints: (255, 0, 0) or [255, 0, 0]
+            - Tuple/list of floats: (1.0, 0.0, 0.0)
+            - Color object: passed through
+
+    Returns:
+        Color object
+
+    Raises:
+        ValueError: If the color format is not recognized
+    """
+    if isinstance(value, Color):
+        return value
+
+    if isinstance(value, str):
+        return Color.from_hex(value)
+
+    if isinstance(value, dict):
+        if "r" in value and "g" in value and "b" in value:
+            return Color(r=int(value["r"]), g=int(value["g"]), b=int(value["b"]))
+        if "red" in value and "green" in value and "blue" in value:
+            # Handle float values (0.0-1.0)
+            r = value["red"]
+            g = value["green"]
+            b = value["blue"]
+            if isinstance(r, float) and r <= 1.0:
+                return Color(r=int(r * 255), g=int(g * 255), b=int(b * 255))
+            return Color(r=int(r), g=int(g), b=int(b))
+        raise ValueError(f"Dict must have r,g,b or red,green,blue keys: {value}")
+
+    if isinstance(value, (tuple, list)):
+        if len(value) < 3:
+            raise ValueError(f"Color tuple must have at least 3 values: {value}")
+        r, g, b = value[0], value[1], value[2]
+        # Check if values are floats in 0-1 range
+        if all(isinstance(v, float) and 0.0 <= v <= 1.0 for v in (r, g, b)):
+            return Color(r=int(r * 255), g=int(g * 255), b=int(b * 255))
+        return Color(r=int(r), g=int(g), b=int(b))
+
+    raise ValueError(f"Unsupported color format: {type(value)}")
+
+
+def color_to_float_tuple(color: Color) -> Tuple[float, float, float]:
+    """
+    Convert a Color to a tuple of floats (0.0-1.0).
+
+    This is used by some terminal emulators like iTerm2.
+
+    Args:
+        color: Color object
+
+    Returns:
+        Tuple of (r, g, b) floats in range 0.0-1.0
+    """
+    return (color.r / 255.0, color.g / 255.0, color.b / 255.0)
+
+
+def float_tuple_to_color(values: Tuple[float, float, float]) -> Color:
+    """
+    Convert a tuple of floats (0.0-1.0) to a Color.
+
+    Args:
+        values: Tuple of (r, g, b) floats
+
+    Returns:
+        Color object
+    """
+    r, g, b = values
+    return Color(r=int(r * 255), g=int(g * 255), b=int(b * 255))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,10 @@ license = "Apache-2.0"
 requires-python = ">=3.10"
 classifiers = []
 dependencies = [
-    "click"
+    "click",
+    "pyyaml>=6.0",
+    "tomli>=2.0",
+    "tomli-w>=1.0",
 ]
 
 [build-system]

--- a/tests/fixtures/alacritty/alacritty.toml
+++ b/tests/fixtures/alacritty/alacritty.toml
@@ -1,0 +1,88 @@
+# Alacritty TOML configuration example
+
+[colors]
+[colors.primary]
+foreground = "#c5c8c6"
+background = "#1d1f21"
+
+[colors.cursor]
+cursor = "#c5c8c6"
+text = "#1d1f21"
+
+[colors.selection]
+background = "#373b41"
+text = "#c5c8c6"
+
+[colors.normal]
+black = "#1d1f21"
+red = "#cc6666"
+green = "#b5bd68"
+yellow = "#f0c674"
+blue = "#81a2be"
+magenta = "#b294bb"
+cyan = "#8abeb7"
+white = "#c5c8c6"
+
+[colors.bright]
+black = "#969896"
+red = "#cc6666"
+green = "#b5bd68"
+yellow = "#f0c674"
+blue = "#81a2be"
+magenta = "#b294bb"
+cyan = "#8abeb7"
+white = "#ffffff"
+
+[font]
+size = 14.0
+
+[font.normal]
+family = "JetBrains Mono"
+
+[font.bold]
+family = "JetBrains Mono"
+
+[font.italic]
+family = "JetBrains Mono"
+
+[font.offset]
+y = 2
+
+[cursor]
+blink_interval = 500
+
+[cursor.style]
+shape = "Block"
+blinking = "On"
+
+[window]
+opacity = 0.95
+dynamic_title = true
+decorations = "Full"
+
+[window.dimensions]
+columns = 120
+lines = 40
+
+[window.padding]
+x = 10
+y = 10
+
+[shell]
+program = "/bin/zsh"
+
+[scrolling]
+history = 10000
+
+[selection]
+save_to_clipboard = true
+
+[[keyboard.bindings]]
+key = "V"
+mods = "Control+Shift"
+action = "Paste"
+
+[[keyboard.bindings]]
+key = "C"
+mods = "Control+Shift"
+action = "Copy"

--- a/tests/fixtures/alacritty/alacritty.yml
+++ b/tests/fixtures/alacritty/alacritty.yml
@@ -1,0 +1,55 @@
+# Alacritty YAML configuration example (legacy format)
+
+colors:
+  primary:
+    foreground: '#c5c8c6'
+    background: '#1d1f21'
+  cursor:
+    cursor: '#c5c8c6'
+    text: '#1d1f21'
+  selection:
+    background: '#373b41'
+    text: '#c5c8c6'
+  normal:
+    black: '#1d1f21'
+    red: '#cc6666'
+    green: '#b5bd68'
+    yellow: '#f0c674'
+    blue: '#81a2be'
+    magenta: '#b294bb'
+    cyan: '#8abeb7'
+    white: '#c5c8c6'
+  bright:
+    black: '#969896'
+    red: '#cc6666'
+    green: '#b5bd68'
+    yellow: '#f0c674'
+    blue: '#81a2be'
+    magenta: '#b294bb'
+    cyan: '#8abeb7'
+    white: '#ffffff'
+
+font:
+  normal:
+    family: JetBrains Mono
+  size: 14.0
+
+cursor:
+  style:
+    shape: Block
+    blinking: On
+
+window:
+  opacity: 0.95
+  dimensions:
+    columns: 120
+    lines: 40
+  padding:
+    x: 10
+    y: 10
+
+shell:
+  program: /bin/zsh
+
+scrolling:
+  history: 10000

--- a/tests/fixtures/ctec/complete.toml
+++ b/tests/fixtures/ctec/complete.toml
@@ -1,0 +1,169 @@
+# Complete CTEC configuration example
+
+version = "1.0"
+source_terminal = "ghostty"
+
+[color_scheme]
+name = "Tomorrow Night"
+
+[color_scheme.foreground]
+r = 197
+g = 200
+b = 198
+
+[color_scheme.background]
+r = 29
+g = 31
+b = 33
+
+[color_scheme.cursor]
+r = 197
+g = 200
+b = 198
+
+[color_scheme.cursor_text]
+r = 29
+g = 31
+b = 33
+
+[color_scheme.selection]
+r = 55
+g = 59
+b = 65
+
+[color_scheme.selection_text]
+r = 197
+g = 200
+b = 198
+
+[color_scheme.black]
+r = 29
+g = 31
+b = 33
+
+[color_scheme.red]
+r = 204
+g = 102
+b = 102
+
+[color_scheme.green]
+r = 181
+g = 189
+b = 104
+
+[color_scheme.yellow]
+r = 240
+g = 198
+b = 116
+
+[color_scheme.blue]
+r = 129
+g = 162
+b = 190
+
+[color_scheme.magenta]
+r = 178
+g = 148
+b = 187
+
+[color_scheme.cyan]
+r = 138
+g = 190
+b = 183
+
+[color_scheme.white]
+r = 197
+g = 200
+b = 198
+
+[color_scheme.bright_black]
+r = 150
+g = 152
+b = 150
+
+[color_scheme.bright_red]
+r = 204
+g = 102
+b = 102
+
+[color_scheme.bright_green]
+r = 181
+g = 189
+b = 104
+
+[color_scheme.bright_yellow]
+r = 240
+g = 198
+b = 116
+
+[color_scheme.bright_blue]
+r = 129
+g = 162
+b = 190
+
+[color_scheme.bright_magenta]
+r = 178
+g = 148
+b = 187
+
+[color_scheme.bright_cyan]
+r = 138
+g = 190
+b = 183
+
+[color_scheme.bright_white]
+r = 255
+g = 255
+b = 255
+
+[font]
+family = "JetBrains Mono"
+size = 14.0
+line_height = 1.1
+bold_font = "JetBrains Mono Bold"
+italic_font = "JetBrains Mono Italic"
+ligatures = true
+
+[cursor]
+style = "block"
+blink = true
+blink_interval = 500
+
+[window]
+columns = 120
+rows = 40
+opacity = 0.95
+blur = 20
+padding_horizontal = 10
+padding_vertical = 10
+decorations = true
+dynamic_title = true
+
+[behavior]
+shell = "/bin/zsh"
+scrollback_lines = 10000
+bell_mode = "visual"
+copy_on_select = true
+confirm_close = true
+
+[[key_bindings]]
+action = "Copy"
+key = "c"
+mods = ["ctrl", "shift"]
+
+[[key_bindings]]
+action = "Paste"
+key = "v"
+mods = ["ctrl", "shift"]
+
+[[profiles]]
+name = "Default"
+is_default = true
+
+[profiles.color_scheme]
+name = "Tomorrow Night"
+
+[[terminal_specific]]
+terminal = "ghostty"
+key = "gtk-single-instance"
+value = true

--- a/tests/fixtures/ctec/minimal.toml
+++ b/tests/fixtures/ctec/minimal.toml
@@ -1,0 +1,11 @@
+# Minimal CTEC configuration
+
+version = "1.0"
+
+[font]
+family = "Fira Code"
+size = 12.0
+
+[cursor]
+style = "beam"
+blink = false

--- a/tests/fixtures/ghostty/config
+++ b/tests/fixtures/ghostty/config
@@ -1,0 +1,58 @@
+# Ghostty configuration example
+# A complete configuration file for testing
+
+# Colors
+foreground = #c5c8c6
+background = #1d1f21
+cursor-color = #c5c8c6
+cursor-text = #1d1f21
+selection-foreground = #1d1f21
+selection-background = #373b41
+
+# Palette colors (Tomorrow Night)
+palette = 0=#1d1f21
+palette = 1=#cc6666
+palette = 2=#b5bd68
+palette = 3=#f0c674
+palette = 4=#81a2be
+palette = 5=#b294bb
+palette = 6=#8abeb7
+palette = 7=#c5c8c6
+palette = 8=#969896
+palette = 9=#cc6666
+palette = 10=#b5bd68
+palette = 11=#f0c674
+palette = 12=#81a2be
+palette = 13=#b294bb
+palette = 14=#8abeb7
+palette = 15=#ffffff
+
+# Font
+font-family = JetBrains Mono
+font-size = 14
+font-family-bold = JetBrains Mono Bold
+font-family-italic = JetBrains Mono Italic
+
+# Cursor
+cursor-style = block
+cursor-style-blink = true
+
+# Window
+window-width = 120
+window-height = 40
+background-opacity = 0.95
+background-blur-radius = 20
+window-padding-x = 10
+window-padding-y = 10
+window-decoration = true
+
+# Behavior
+command = /bin/zsh
+scrollback-limit = 10000
+copy-on-select = true
+confirm-close-surface = true
+mouse-hide-while-typing = true
+
+# Ghostty-specific settings
+gtk-single-instance = true
+shell-integration = detect

--- a/tests/fixtures/iterm2/com.googlecode.iterm2.plist
+++ b/tests/fixtures/iterm2/com.googlecode.iterm2.plist
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>New Bookmarks</key>
+    <array>
+        <dict>
+            <key>Name</key>
+            <string>Default</string>
+            <key>Guid</key>
+            <string>default-profile</string>
+            <key>Default Bookmark</key>
+            <string>Yes</string>
+            <key>Normal Font</key>
+            <string>JetBrainsMono-Regular 14</string>
+            <key>Cursor Type</key>
+            <integer>1</integer>
+            <key>Blinking Cursor</key>
+            <true/>
+            <key>Scrollback Lines</key>
+            <integer>10000</integer>
+            <key>Silence Bell</key>
+            <false/>
+            <key>Visual Bell</key>
+            <true/>
+            <key>Command</key>
+            <string>/bin/zsh</string>
+            <key>Foreground Color</key>
+            <dict>
+                <key>Color Space</key>
+                <string>sRGB</string>
+                <key>Red Component</key>
+                <real>0.77254901960784317</real>
+                <key>Green Component</key>
+                <real>0.78431372549019607</real>
+                <key>Blue Component</key>
+                <real>0.77647058823529413</real>
+            </dict>
+            <key>Background Color</key>
+            <dict>
+                <key>Color Space</key>
+                <string>sRGB</string>
+                <key>Red Component</key>
+                <real>0.11372549019607843</real>
+                <key>Green Component</key>
+                <real>0.12156862745098039</real>
+                <key>Blue Component</key>
+                <real>0.12941176470588237</real>
+            </dict>
+            <key>Cursor Color</key>
+            <dict>
+                <key>Color Space</key>
+                <string>sRGB</string>
+                <key>Red Component</key>
+                <real>0.77254901960784317</real>
+                <key>Green Component</key>
+                <real>0.78431372549019607</real>
+                <key>Blue Component</key>
+                <real>0.77647058823529413</real>
+            </dict>
+            <key>Ansi 0 Color</key>
+            <dict>
+                <key>Color Space</key>
+                <string>sRGB</string>
+                <key>Red Component</key>
+                <real>0.11372549019607843</real>
+                <key>Green Component</key>
+                <real>0.12156862745098039</real>
+                <key>Blue Component</key>
+                <real>0.12941176470588237</real>
+            </dict>
+            <key>Ansi 1 Color</key>
+            <dict>
+                <key>Color Space</key>
+                <string>sRGB</string>
+                <key>Red Component</key>
+                <real>0.80000000000000004</real>
+                <key>Green Component</key>
+                <real>0.40000000000000002</real>
+                <key>Blue Component</key>
+                <real>0.40000000000000002</real>
+            </dict>
+            <key>Ansi 2 Color</key>
+            <dict>
+                <key>Color Space</key>
+                <string>sRGB</string>
+                <key>Red Component</key>
+                <real>0.70980392156862748</real>
+                <key>Green Component</key>
+                <real>0.74117647058823533</real>
+                <key>Blue Component</key>
+                <real>0.40784313725490196</real>
+            </dict>
+            <key>Ansi 3 Color</key>
+            <dict>
+                <key>Color Space</key>
+                <string>sRGB</string>
+                <key>Red Component</key>
+                <real>0.94117647058823528</real>
+                <key>Green Component</key>
+                <real>0.77647058823529413</real>
+                <key>Blue Component</key>
+                <real>0.45490196078431372</real>
+            </dict>
+            <key>Ansi 4 Color</key>
+            <dict>
+                <key>Color Space</key>
+                <string>sRGB</string>
+                <key>Red Component</key>
+                <real>0.50588235294117645</real>
+                <key>Green Component</key>
+                <real>0.63529411764705879</real>
+                <key>Blue Component</key>
+                <real>0.74509803921568629</real>
+            </dict>
+            <key>Ansi 5 Color</key>
+            <dict>
+                <key>Color Space</key>
+                <string>sRGB</string>
+                <key>Red Component</key>
+                <real>0.69803921568627447</real>
+                <key>Green Component</key>
+                <real>0.58039215686274515</real>
+                <key>Blue Component</key>
+                <real>0.73333333333333328</real>
+            </dict>
+            <key>Ansi 6 Color</key>
+            <dict>
+                <key>Color Space</key>
+                <string>sRGB</string>
+                <key>Red Component</key>
+                <real>0.54117647058823526</real>
+                <key>Green Component</key>
+                <real>0.74509803921568629</real>
+                <key>Blue Component</key>
+                <real>0.71764705882352942</real>
+            </dict>
+            <key>Ansi 7 Color</key>
+            <dict>
+                <key>Color Space</key>
+                <string>sRGB</string>
+                <key>Red Component</key>
+                <real>0.77254901960784317</real>
+                <key>Green Component</key>
+                <real>0.78431372549019607</real>
+                <key>Blue Component</key>
+                <real>0.77647058823529413</real>
+            </dict>
+            <key>Unlimited Scrollback</key>
+            <false/>
+            <key>Use Bold Font</key>
+            <true/>
+        </dict>
+    </array>
+    <key>Default Bookmark Window Width</key>
+    <integer>120</integer>
+    <key>Default Bookmark Window Height</key>
+    <integer>40</integer>
+    <key>HideTab</key>
+    <false/>
+    <key>PromptOnQuit</key>
+    <true/>
+</dict>
+</plist>

--- a/tests/fixtures/kitty/kitty.conf
+++ b/tests/fixtures/kitty/kitty.conf
@@ -1,0 +1,72 @@
+# Kitty configuration example
+
+# Colors (Tomorrow Night theme)
+foreground #c5c8c6
+background #1d1f21
+cursor #c5c8c6
+cursor_text_color #1d1f21
+selection_foreground #c5c8c6
+selection_background #373b41
+
+# ANSI colors
+color0 #1d1f21
+color1 #cc6666
+color2 #b5bd68
+color3 #f0c674
+color4 #81a2be
+color5 #b294bb
+color6 #8abeb7
+color7 #c5c8c6
+
+# Bright colors
+color8 #969896
+color9 #cc6666
+color10 #b5bd68
+color11 #f0c674
+color12 #81a2be
+color13 #b294bb
+color14 #8abeb7
+color15 #ffffff
+
+# Font
+font_family JetBrains Mono
+font_size 14.0
+bold_font JetBrains Mono Bold
+italic_font JetBrains Mono Italic
+adjust_line_height 110%
+disable_ligatures never
+
+# Cursor
+cursor_shape block
+cursor_blink_interval 0.5
+
+# Window
+initial_window_width 120c
+initial_window_height 40c
+background_opacity 0.95
+background_blur 20
+window_padding_width 10
+hide_window_decorations no
+dynamic_title yes
+
+# Behavior
+shell /bin/zsh
+scrollback_lines 10000
+enable_audio_bell no
+visual_bell_duration 0.1
+copy_on_select yes
+confirm_os_window_close 1
+close_on_child_death no
+
+# Mouse
+mouse_hide_wait 3.0
+
+# Key bindings
+map ctrl+shift+c copy_to_clipboard
+map ctrl+shift+v paste_from_clipboard
+map ctrl+shift+t new_tab
+map ctrl+shift+w close_tab
+
+# Kitty-specific settings
+allow_remote_control yes
+listen_on unix:/tmp/kitty

--- a/tests/fixtures/wezterm/wezterm.lua
+++ b/tests/fixtures/wezterm/wezterm.lua
@@ -1,0 +1,57 @@
+-- Wezterm configuration example
+
+local wezterm = require 'wezterm'
+local config = wezterm.config_builder()
+
+-- Colors (Tomorrow Night theme)
+config.colors = {
+  foreground = "#c5c8c6",
+  background = "#1d1f21",
+  cursor_bg = "#c5c8c6",
+  cursor_fg = "#1d1f21",
+  selection_bg = "#373b41",
+  selection_fg = "#c5c8c6",
+  ansi = { "#1d1f21", "#cc6666", "#b5bd68", "#f0c674", "#81a2be", "#b294bb", "#8abeb7", "#c5c8c6" },
+  brights = { "#969896", "#cc6666", "#b5bd68", "#f0c674", "#81a2be", "#b294bb", "#8abeb7", "#ffffff" },
+}
+
+-- Font
+config.font = wezterm.font("JetBrains Mono")
+config.font_size = 14.0
+config.line_height = 1.1
+
+-- Cursor
+config.default_cursor_style = "BlinkingBlock"
+config.cursor_blink_rate = 500
+
+-- Window
+config.initial_cols = 120
+config.initial_rows = 40
+config.window_background_opacity = 0.95
+config.window_padding = {
+  left = 10,
+  right = 10,
+  top = 10,
+  bottom = 10,
+}
+config.window_decorations = "FULL"
+
+-- Behavior
+config.default_prog = { "/bin/zsh" }
+config.scrollback_lines = 10000
+config.audible_bell = "Disabled"
+config.visual_bell = {
+  fade_in_function = "EaseIn",
+  fade_in_duration_ms = 50,
+  fade_out_function = "EaseOut",
+  fade_out_duration_ms = 50,
+}
+
+-- Key bindings
+config.keys = {
+  { key = "c", mods = "CTRL|SHIFT", action = wezterm.action.CopyTo("Clipboard") },
+  { key = "v", mods = "CTRL|SHIFT", action = wezterm.action.PasteFrom("Clipboard") },
+  { key = "t", mods = "CTRL|SHIFT", action = wezterm.action.SpawnTab("CurrentPaneDomain") },
+}
+
+return config

--- a/tests/test_console_cowboy.py
+++ b/tests/test_console_cowboy.py
@@ -1,10 +1,429 @@
+"""Tests for the console-cowboy CLI."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+import tomli
+import yaml
 from click.testing import CliRunner
+
 from console_cowboy.cli import cli
 
 
-def test_version():
-    runner = CliRunner()
-    with runner.isolated_filesystem():
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def runner():
+    """Create a CLI runner."""
+    return CliRunner()
+
+
+class TestCLIBasics:
+    """Basic CLI tests."""
+
+    def test_version(self, runner):
         result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
-        assert result.output.startswith("cli, version ")
+        assert "version" in result.output.lower()
+
+    def test_help(self, runner):
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "Console Cowboy" in result.output
+        assert "export" in result.output
+        assert "import" in result.output
+
+    def test_list_command(self, runner):
+        result = runner.invoke(cli, ["list"])
+        assert result.exit_code == 0
+        assert "iterm2" in result.output.lower()
+        assert "ghostty" in result.output.lower()
+        assert "alacritty" in result.output.lower()
+        assert "kitty" in result.output.lower()
+        assert "wezterm" in result.output.lower()
+
+
+class TestExportCommand:
+    """Tests for the export command."""
+
+    def test_export_ghostty_to_stdout(self, runner):
+        config_path = FIXTURES_DIR / "ghostty" / "config"
+        result = runner.invoke(cli, ["export", "ghostty", "-i", str(config_path), "-q"])
+
+        assert result.exit_code == 0
+        # Should be valid TOML by default
+        parsed = tomli.loads(result.output)
+        assert parsed["version"] == "1.0"
+        assert parsed["source_terminal"] == "ghostty"
+
+    def test_export_ghostty_to_file(self, runner):
+        config_path = FIXTURES_DIR / "ghostty" / "config"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "output.toml"
+            result = runner.invoke(
+                cli,
+                ["export", "ghostty", "-i", str(config_path), "-o", str(output_path)],
+            )
+
+            assert result.exit_code == 0
+            assert output_path.exists()
+            content = output_path.read_text()
+            parsed = tomli.loads(content)
+            assert parsed["source_terminal"] == "ghostty"
+
+    def test_export_to_json(self, runner):
+        config_path = FIXTURES_DIR / "ghostty" / "config"
+        result = runner.invoke(
+            cli, ["export", "ghostty", "-i", str(config_path), "-f", "json", "-q"]
+        )
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["source_terminal"] == "ghostty"
+
+    def test_export_to_yaml(self, runner):
+        config_path = FIXTURES_DIR / "ghostty" / "config"
+        result = runner.invoke(
+            cli, ["export", "ghostty", "-i", str(config_path), "-f", "yaml", "-q"]
+        )
+
+        assert result.exit_code == 0
+        parsed = yaml.safe_load(result.output)
+        assert parsed["source_terminal"] == "ghostty"
+
+    def test_export_kitty(self, runner):
+        config_path = FIXTURES_DIR / "kitty" / "kitty.conf"
+        result = runner.invoke(cli, ["export", "kitty", "-i", str(config_path), "-q"])
+
+        assert result.exit_code == 0
+        parsed = tomli.loads(result.output)
+        assert parsed["source_terminal"] == "kitty"
+
+    def test_export_alacritty_toml(self, runner):
+        config_path = FIXTURES_DIR / "alacritty" / "alacritty.toml"
+        result = runner.invoke(
+            cli, ["export", "alacritty", "-i", str(config_path), "-q"]
+        )
+
+        assert result.exit_code == 0
+        parsed = tomli.loads(result.output)
+        assert parsed["source_terminal"] == "alacritty"
+
+    def test_export_alacritty_yaml(self, runner):
+        config_path = FIXTURES_DIR / "alacritty" / "alacritty.yml"
+        result = runner.invoke(
+            cli, ["export", "alacritty", "-i", str(config_path), "-q"]
+        )
+
+        assert result.exit_code == 0
+        parsed = tomli.loads(result.output)
+        assert parsed["source_terminal"] == "alacritty"
+
+    def test_export_wezterm(self, runner):
+        config_path = FIXTURES_DIR / "wezterm" / "wezterm.lua"
+        result = runner.invoke(
+            cli, ["export", "wezterm", "-i", str(config_path), "-q"]
+        )
+
+        assert result.exit_code == 0
+        parsed = tomli.loads(result.output)
+        assert parsed["source_terminal"] == "wezterm"
+
+    def test_export_iterm2(self, runner):
+        config_path = FIXTURES_DIR / "iterm2" / "com.googlecode.iterm2.plist"
+        result = runner.invoke(cli, ["export", "iterm2", "-i", str(config_path), "-q"])
+
+        assert result.exit_code == 0
+        parsed = tomli.loads(result.output)
+        assert parsed["source_terminal"] == "iterm2"
+
+    def test_export_nonexistent_file(self, runner):
+        result = runner.invoke(
+            cli, ["export", "ghostty", "-i", "/nonexistent/path"]
+        )
+        assert result.exit_code != 0
+        assert "Error" in result.output or "not found" in result.output.lower()
+
+    def test_export_shows_warnings(self, runner):
+        config_path = FIXTURES_DIR / "wezterm" / "wezterm.lua"
+        result = runner.invoke(cli, ["export", "wezterm", "-i", str(config_path)])
+
+        # Wezterm should show warnings about Lua parsing
+        assert "Warning" in result.output or result.exit_code == 0
+
+
+class TestImportCommand:
+    """Tests for the import command."""
+
+    def test_import_ctec_to_ghostty(self, runner):
+        ctec_path = FIXTURES_DIR / "ctec" / "complete.toml"
+        result = runner.invoke(cli, ["import", str(ctec_path), "-t", "ghostty", "-q"])
+
+        assert result.exit_code == 0
+        assert "font-family" in result.output
+        assert "JetBrains Mono" in result.output
+
+    def test_import_ctec_to_alacritty(self, runner):
+        ctec_path = FIXTURES_DIR / "ctec" / "complete.toml"
+        result = runner.invoke(cli, ["import", str(ctec_path), "-t", "alacritty", "-q"])
+
+        assert result.exit_code == 0
+        # Should be TOML output
+        parsed = tomli.loads(result.output)
+        assert "colors" in parsed or "font" in parsed
+
+    def test_import_ctec_to_kitty(self, runner):
+        ctec_path = FIXTURES_DIR / "ctec" / "complete.toml"
+        result = runner.invoke(cli, ["import", str(ctec_path), "-t", "kitty", "-q"])
+
+        assert result.exit_code == 0
+        assert "font_family" in result.output
+
+    def test_import_ctec_to_wezterm(self, runner):
+        ctec_path = FIXTURES_DIR / "ctec" / "complete.toml"
+        result = runner.invoke(cli, ["import", str(ctec_path), "-t", "wezterm", "-q"])
+
+        assert result.exit_code == 0
+        assert "wezterm" in result.output
+        assert "return config" in result.output
+
+    def test_import_ctec_to_iterm2(self, runner):
+        ctec_path = FIXTURES_DIR / "ctec" / "complete.toml"
+        result = runner.invoke(cli, ["import", str(ctec_path), "-t", "iterm2", "-q"])
+
+        assert result.exit_code == 0
+        assert "plist" in result.output.lower()
+
+    def test_import_to_file(self, runner):
+        ctec_path = FIXTURES_DIR / "ctec" / "minimal.toml"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "output"
+            result = runner.invoke(
+                cli,
+                [
+                    "import",
+                    str(ctec_path),
+                    "-t",
+                    "ghostty",
+                    "-o",
+                    str(output_path),
+                ],
+            )
+
+            assert result.exit_code == 0
+            assert output_path.exists()
+            content = output_path.read_text()
+            assert "Fira Code" in content
+
+    def test_import_with_explicit_format(self, runner):
+        ctec_path = FIXTURES_DIR / "ctec" / "complete.toml"
+        result = runner.invoke(
+            cli, ["import", str(ctec_path), "-t", "ghostty", "-f", "toml", "-q"]
+        )
+
+        assert result.exit_code == 0
+
+    def test_import_missing_terminal(self, runner):
+        ctec_path = FIXTURES_DIR / "ctec" / "complete.toml"
+        result = runner.invoke(cli, ["import", str(ctec_path)])
+
+        assert result.exit_code != 0
+        assert "Missing option" in result.output or "required" in result.output.lower()
+
+
+class TestConvertCommand:
+    """Tests for the convert command."""
+
+    def test_convert_ghostty_to_alacritty(self, runner):
+        config_path = FIXTURES_DIR / "ghostty" / "config"
+        result = runner.invoke(
+            cli,
+            [
+                "convert",
+                str(config_path),
+                "-f",
+                "ghostty",
+                "-t",
+                "alacritty",
+                "-q",
+            ],
+        )
+
+        assert result.exit_code == 0
+        # Should produce valid Alacritty TOML
+        parsed = tomli.loads(result.output)
+        assert "font" in parsed or "colors" in parsed
+
+    def test_convert_kitty_to_ghostty(self, runner):
+        config_path = FIXTURES_DIR / "kitty" / "kitty.conf"
+        result = runner.invoke(
+            cli,
+            [
+                "convert",
+                str(config_path),
+                "-f",
+                "kitty",
+                "-t",
+                "ghostty",
+                "-q",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "font-family" in result.output
+
+    def test_convert_alacritty_to_wezterm(self, runner):
+        config_path = FIXTURES_DIR / "alacritty" / "alacritty.toml"
+        result = runner.invoke(
+            cli,
+            [
+                "convert",
+                str(config_path),
+                "-f",
+                "alacritty",
+                "-t",
+                "wezterm",
+                "-q",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "wezterm" in result.output
+        assert "return config" in result.output
+
+    def test_convert_to_file(self, runner):
+        config_path = FIXTURES_DIR / "ghostty" / "config"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "output.toml"
+            result = runner.invoke(
+                cli,
+                [
+                    "convert",
+                    str(config_path),
+                    "-f",
+                    "ghostty",
+                    "-t",
+                    "alacritty",
+                    "-o",
+                    str(output_path),
+                ],
+            )
+
+            assert result.exit_code == 0
+            assert output_path.exists()
+
+    def test_convert_shows_incompatibilities(self, runner):
+        config_path = FIXTURES_DIR / "ghostty" / "config"
+        result = runner.invoke(
+            cli,
+            [
+                "convert",
+                str(config_path),
+                "-f",
+                "ghostty",
+                "-t",
+                "alacritty",
+            ],
+        )
+
+        # Should mention terminal-specific settings
+        assert result.exit_code == 0
+
+
+class TestInfoCommand:
+    """Tests for the info command."""
+
+    def test_info_ctec_file(self, runner):
+        ctec_path = FIXTURES_DIR / "ctec" / "complete.toml"
+        result = runner.invoke(cli, ["info", str(ctec_path)])
+
+        assert result.exit_code == 0
+        assert "Configuration Summary" in result.output
+        assert "Font" in result.output
+        assert "JetBrains Mono" in result.output
+
+    def test_info_native_config(self, runner):
+        config_path = FIXTURES_DIR / "ghostty" / "config"
+        result = runner.invoke(cli, ["info", str(config_path), "-t", "ghostty"])
+
+        assert result.exit_code == 0
+        assert "Configuration Summary" in result.output
+        assert "ghostty" in result.output.lower()
+
+    def test_info_minimal_config(self, runner):
+        ctec_path = FIXTURES_DIR / "ctec" / "minimal.toml"
+        result = runner.invoke(cli, ["info", str(ctec_path)])
+
+        assert result.exit_code == 0
+        assert "Font" in result.output
+        assert "Cursor" in result.output
+
+
+class TestRoundTrip:
+    """Round-trip integration tests."""
+
+    def test_ghostty_roundtrip(self, runner):
+        """Test export -> import -> compare."""
+        config_path = FIXTURES_DIR / "ghostty" / "config"
+
+        # Export to CTEC
+        export_result = runner.invoke(
+            cli, ["export", "ghostty", "-i", str(config_path), "-q"]
+        )
+        assert export_result.exit_code == 0
+
+        # Import back to Ghostty
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            f.write(export_result.output)
+            ctec_path = f.name
+
+        try:
+            import_result = runner.invoke(
+                cli, ["import", ctec_path, "-t", "ghostty", "-q"]
+            )
+            assert import_result.exit_code == 0
+
+            # Key settings should be preserved
+            assert "JetBrains Mono" in import_result.output
+            assert "font-size = 14" in import_result.output
+        finally:
+            Path(ctec_path).unlink()
+
+    def test_all_terminals_export_import(self, runner):
+        """Test that all terminals can export and import."""
+        terminals_and_fixtures = [
+            ("ghostty", "ghostty/config"),
+            ("kitty", "kitty/kitty.conf"),
+            ("alacritty", "alacritty/alacritty.toml"),
+            ("wezterm", "wezterm/wezterm.lua"),
+            ("iterm2", "iterm2/com.googlecode.iterm2.plist"),
+        ]
+
+        for terminal, fixture in terminals_and_fixtures:
+            config_path = FIXTURES_DIR / fixture
+
+            # Export
+            export_result = runner.invoke(
+                cli, ["export", terminal, "-i", str(config_path), "-q"]
+            )
+            assert export_result.exit_code == 0, f"Export failed for {terminal}"
+
+            # Verify it's valid TOML
+            parsed = tomli.loads(export_result.output)
+            assert parsed["source_terminal"] == terminal
+
+            # Import to same terminal
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+                f.write(export_result.output)
+                ctec_path = f.name
+
+            try:
+                import_result = runner.invoke(
+                    cli, ["import", ctec_path, "-t", terminal, "-q"]
+                )
+                assert import_result.exit_code == 0, f"Import failed for {terminal}"
+            finally:
+                Path(ctec_path).unlink()

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,0 +1,269 @@
+"""Tests for CTEC serializers (TOML, JSON, YAML)."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+import tomli
+import yaml
+
+from console_cowboy.ctec.schema import (
+    CTEC,
+    Color,
+    ColorScheme,
+    CursorConfig,
+    CursorStyle,
+    FontConfig,
+)
+from console_cowboy.ctec.serializers import CTECSerializer, OutputFormat
+
+
+@pytest.fixture
+def sample_ctec():
+    """Create a sample CTEC configuration for testing."""
+    return CTEC(
+        source_terminal="test",
+        color_scheme=ColorScheme(
+            foreground=Color(255, 255, 255),
+            background=Color(0, 0, 0),
+        ),
+        font=FontConfig(family="JetBrains Mono", size=14.0),
+        cursor=CursorConfig(style=CursorStyle.BLOCK, blink=True),
+    )
+
+
+class TestOutputFormat:
+    """Tests for OutputFormat enum."""
+
+    def test_format_values(self):
+        assert OutputFormat.TOML.value == "toml"
+        assert OutputFormat.JSON.value == "json"
+        assert OutputFormat.YAML.value == "yaml"
+
+
+class TestTOMLSerialization:
+    """Tests for TOML serialization."""
+
+    def test_to_toml(self, sample_ctec):
+        output = CTECSerializer.to_toml(sample_ctec)
+        assert isinstance(output, str)
+
+        # Parse the output and verify
+        parsed = tomli.loads(output)
+        assert parsed["version"] == "1.0"
+        assert parsed["source_terminal"] == "test"
+        assert parsed["font"]["family"] == "JetBrains Mono"
+
+    def test_from_toml(self):
+        toml_content = """
+version = "1.0"
+source_terminal = "kitty"
+
+[font]
+family = "Fira Code"
+size = 12.0
+
+[cursor]
+style = "beam"
+blink = false
+"""
+        ctec = CTECSerializer.from_toml(toml_content)
+        assert ctec.source_terminal == "kitty"
+        assert ctec.font.family == "Fira Code"
+        assert ctec.cursor.style == CursorStyle.BEAM
+
+    def test_toml_roundtrip(self, sample_ctec):
+        toml_str = CTECSerializer.to_toml(sample_ctec)
+        restored = CTECSerializer.from_toml(toml_str)
+
+        assert restored.source_terminal == sample_ctec.source_terminal
+        assert restored.font.family == sample_ctec.font.family
+        assert restored.cursor.style == sample_ctec.cursor.style
+
+
+class TestJSONSerialization:
+    """Tests for JSON serialization."""
+
+    def test_to_json(self, sample_ctec):
+        output = CTECSerializer.to_json(sample_ctec)
+        assert isinstance(output, str)
+
+        # Parse the output and verify
+        parsed = json.loads(output)
+        assert parsed["version"] == "1.0"
+        assert parsed["source_terminal"] == "test"
+        assert parsed["font"]["family"] == "JetBrains Mono"
+
+    def test_to_json_with_indent(self, sample_ctec):
+        output = CTECSerializer.to_json(sample_ctec, indent=4)
+        # Check that it's properly indented
+        assert "    " in output
+
+    def test_from_json(self):
+        json_content = """
+{
+    "version": "1.0",
+    "source_terminal": "alacritty",
+    "font": {
+        "family": "Monaco",
+        "size": 13.0
+    }
+}
+"""
+        ctec = CTECSerializer.from_json(json_content)
+        assert ctec.source_terminal == "alacritty"
+        assert ctec.font.family == "Monaco"
+        assert ctec.font.size == 13.0
+
+    def test_json_roundtrip(self, sample_ctec):
+        json_str = CTECSerializer.to_json(sample_ctec)
+        restored = CTECSerializer.from_json(json_str)
+
+        assert restored.source_terminal == sample_ctec.source_terminal
+        assert restored.font.family == sample_ctec.font.family
+
+
+class TestYAMLSerialization:
+    """Tests for YAML serialization."""
+
+    def test_to_yaml(self, sample_ctec):
+        output = CTECSerializer.to_yaml(sample_ctec)
+        assert isinstance(output, str)
+
+        # Parse the output and verify
+        parsed = yaml.safe_load(output)
+        assert parsed["version"] == "1.0"
+        assert parsed["source_terminal"] == "test"
+        assert parsed["font"]["family"] == "JetBrains Mono"
+
+    def test_from_yaml(self):
+        yaml_content = """
+version: "1.0"
+source_terminal: ghostty
+font:
+  family: Fira Code
+  size: 12.0
+cursor:
+  style: underline
+  blink: true
+"""
+        ctec = CTECSerializer.from_yaml(yaml_content)
+        assert ctec.source_terminal == "ghostty"
+        assert ctec.font.family == "Fira Code"
+        assert ctec.cursor.style == CursorStyle.UNDERLINE
+
+    def test_yaml_roundtrip(self, sample_ctec):
+        yaml_str = CTECSerializer.to_yaml(sample_ctec)
+        restored = CTECSerializer.from_yaml(yaml_str)
+
+        assert restored.source_terminal == sample_ctec.source_terminal
+        assert restored.font.family == sample_ctec.font.family
+
+
+class TestSerializeMethod:
+    """Tests for the generic serialize method."""
+
+    def test_serialize_toml(self, sample_ctec):
+        output = CTECSerializer.serialize(sample_ctec, OutputFormat.TOML)
+        parsed = tomli.loads(output)
+        assert parsed["version"] == "1.0"
+
+    def test_serialize_json(self, sample_ctec):
+        output = CTECSerializer.serialize(sample_ctec, OutputFormat.JSON)
+        parsed = json.loads(output)
+        assert parsed["version"] == "1.0"
+
+    def test_serialize_yaml(self, sample_ctec):
+        output = CTECSerializer.serialize(sample_ctec, OutputFormat.YAML)
+        parsed = yaml.safe_load(output)
+        assert parsed["version"] == "1.0"
+
+
+class TestDeserializeMethod:
+    """Tests for the generic deserialize method."""
+
+    def test_deserialize_toml(self):
+        content = 'version = "1.0"\n[font]\nfamily = "Test"'
+        ctec = CTECSerializer.deserialize(content, OutputFormat.TOML)
+        assert ctec.font.family == "Test"
+
+    def test_deserialize_json(self):
+        content = '{"version": "1.0", "font": {"family": "Test"}}'
+        ctec = CTECSerializer.deserialize(content, OutputFormat.JSON)
+        assert ctec.font.family == "Test"
+
+    def test_deserialize_yaml(self):
+        content = "version: '1.0'\nfont:\n  family: Test"
+        ctec = CTECSerializer.deserialize(content, OutputFormat.YAML)
+        assert ctec.font.family == "Test"
+
+
+class TestFormatDetection:
+    """Tests for format detection from file extension."""
+
+    def test_detect_toml(self):
+        assert CTECSerializer.detect_format("config.toml") == OutputFormat.TOML
+
+    def test_detect_json(self):
+        assert CTECSerializer.detect_format("config.json") == OutputFormat.JSON
+
+    def test_detect_yaml(self):
+        assert CTECSerializer.detect_format("config.yaml") == OutputFormat.YAML
+        assert CTECSerializer.detect_format("config.yml") == OutputFormat.YAML
+
+    def test_detect_unknown_raises(self):
+        with pytest.raises(ValueError):
+            CTECSerializer.detect_format("config.txt")
+
+    def test_detect_with_path_object(self):
+        assert CTECSerializer.detect_format(Path("config.toml")) == OutputFormat.TOML
+
+
+class TestFileOperations:
+    """Tests for file read/write operations."""
+
+    def test_write_and_read_toml(self, sample_ctec):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "config.toml"
+            CTECSerializer.write_file(sample_ctec, path)
+
+            restored = CTECSerializer.read_file(path)
+            assert restored.font.family == sample_ctec.font.family
+
+    def test_write_and_read_json(self, sample_ctec):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "config.json"
+            CTECSerializer.write_file(sample_ctec, path)
+
+            restored = CTECSerializer.read_file(path)
+            assert restored.font.family == sample_ctec.font.family
+
+    def test_write_and_read_yaml(self, sample_ctec):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "config.yaml"
+            CTECSerializer.write_file(sample_ctec, path)
+
+            restored = CTECSerializer.read_file(path)
+            assert restored.font.family == sample_ctec.font.family
+
+    def test_read_with_explicit_format(self, sample_ctec):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Write as TOML but with .txt extension
+            path = Path(tmpdir) / "config.txt"
+            path.write_text(CTECSerializer.to_toml(sample_ctec))
+
+            # Read with explicit format
+            restored = CTECSerializer.read_file(path, OutputFormat.TOML)
+            assert restored.font.family == sample_ctec.font.family
+
+    def test_write_with_explicit_format(self, sample_ctec):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Write as JSON but with .txt extension
+            path = Path(tmpdir) / "config.txt"
+            CTECSerializer.write_file(sample_ctec, path, OutputFormat.JSON)
+
+            # Verify it's valid JSON
+            content = path.read_text()
+            parsed = json.loads(content)
+            assert parsed["font"]["family"] == sample_ctec.font.family

--- a/tests/test_terminals.py
+++ b/tests/test_terminals.py
@@ -1,0 +1,455 @@
+"""Tests for terminal emulator adapters."""
+
+from pathlib import Path
+
+import pytest
+
+from console_cowboy.ctec.schema import (
+    CTEC,
+    BellMode,
+    Color,
+    ColorScheme,
+    CursorConfig,
+    CursorStyle,
+    FontConfig,
+    WindowConfig,
+)
+from console_cowboy.terminals import (
+    AlacrittyAdapter,
+    GhosttyAdapter,
+    ITerm2Adapter,
+    KittyAdapter,
+    TerminalRegistry,
+    WeztermAdapter,
+)
+
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class TestTerminalRegistry:
+    """Tests for the terminal registry."""
+
+    def test_get_all_terminals(self):
+        names = TerminalRegistry.get_names()
+        assert "iterm2" in names
+        assert "ghostty" in names
+        assert "alacritty" in names
+        assert "kitty" in names
+        assert "wezterm" in names
+
+    def test_get_terminal_by_name(self):
+        adapter = TerminalRegistry.get("ghostty")
+        assert adapter == GhosttyAdapter
+
+    def test_get_terminal_case_insensitive(self):
+        adapter = TerminalRegistry.get("GHOSTTY")
+        assert adapter == GhosttyAdapter
+
+    def test_get_unknown_terminal(self):
+        adapter = TerminalRegistry.get("unknown")
+        assert adapter is None
+
+    def test_list_terminals(self):
+        terminals = TerminalRegistry.list_terminals()
+        assert len(terminals) == 5
+        assert ITerm2Adapter in terminals
+
+
+class TestGhosttyAdapter:
+    """Tests for the Ghostty adapter."""
+
+    def test_adapter_metadata(self):
+        assert GhosttyAdapter.name == "ghostty"
+        assert GhosttyAdapter.display_name == "Ghostty"
+        assert ".config/ghostty/config" in GhosttyAdapter.default_config_paths
+
+    def test_parse_fixture(self):
+        config_path = FIXTURES_DIR / "ghostty" / "config"
+        ctec = GhosttyAdapter.parse(config_path)
+
+        assert ctec.source_terminal == "ghostty"
+        assert ctec.font.family == "JetBrains Mono"
+        assert ctec.font.size == 14.0
+        assert ctec.cursor.style == CursorStyle.BLOCK
+        assert ctec.cursor.blink is True
+        assert ctec.window.columns == 120
+        assert ctec.window.rows == 40
+        assert ctec.window.opacity == 0.95
+
+    def test_parse_colors(self):
+        config_path = FIXTURES_DIR / "ghostty" / "config"
+        ctec = GhosttyAdapter.parse(config_path)
+
+        assert ctec.color_scheme is not None
+        # Check foreground (#c5c8c6)
+        assert ctec.color_scheme.foreground.r == 197
+        assert ctec.color_scheme.foreground.g == 200
+        assert ctec.color_scheme.foreground.b == 198
+        # Check background (#1d1f21)
+        assert ctec.color_scheme.background.r == 29
+
+    def test_parse_from_content(self):
+        content = """
+font-family = Test Font
+font-size = 16
+cursor-style = bar
+"""
+        ctec = GhosttyAdapter.parse("test", content=content)
+        assert ctec.font.family == "Test Font"
+        assert ctec.font.size == 16.0
+        assert ctec.cursor.style == CursorStyle.BEAM
+
+    def test_export(self):
+        ctec = CTEC(
+            font=FontConfig(family="Fira Code", size=12.0),
+            cursor=CursorConfig(style=CursorStyle.UNDERLINE, blink=False),
+        )
+        output = GhosttyAdapter.export(ctec)
+
+        assert "font-family = Fira Code" in output
+        assert "font-size = 12.0" in output
+        assert "cursor-style = underline" in output
+        assert "cursor-style-blink = false" in output
+
+    def test_export_colors(self):
+        ctec = CTEC(
+            color_scheme=ColorScheme(
+                foreground=Color(255, 255, 255),
+                background=Color(0, 0, 0),
+                red=Color(204, 0, 0),
+            )
+        )
+        output = GhosttyAdapter.export(ctec)
+
+        assert "foreground = #ffffff" in output
+        assert "background = #000000" in output
+        assert "palette = 1=#cc0000" in output
+
+    def test_roundtrip(self):
+        config_path = FIXTURES_DIR / "ghostty" / "config"
+        original = GhosttyAdapter.parse(config_path)
+
+        # Export and re-parse
+        exported = GhosttyAdapter.export(original)
+        restored = GhosttyAdapter.parse("test", content=exported)
+
+        assert restored.font.family == original.font.family
+        assert restored.font.size == original.font.size
+        assert restored.cursor.style == original.cursor.style
+
+
+class TestAlacrittyAdapter:
+    """Tests for the Alacritty adapter."""
+
+    def test_adapter_metadata(self):
+        assert AlacrittyAdapter.name == "alacritty"
+        assert ".toml" in AlacrittyAdapter.config_extensions
+
+    def test_parse_toml_fixture(self):
+        config_path = FIXTURES_DIR / "alacritty" / "alacritty.toml"
+        ctec = AlacrittyAdapter.parse(config_path)
+
+        assert ctec.source_terminal == "alacritty"
+        assert ctec.font.family == "JetBrains Mono"
+        assert ctec.font.size == 14.0
+        assert ctec.cursor.style == CursorStyle.BLOCK
+        assert ctec.window.columns == 120
+        assert ctec.window.rows == 40
+
+    def test_parse_yaml_fixture(self):
+        config_path = FIXTURES_DIR / "alacritty" / "alacritty.yml"
+        ctec = AlacrittyAdapter.parse(config_path)
+
+        assert ctec.source_terminal == "alacritty"
+        assert ctec.font.family == "JetBrains Mono"
+
+    def test_parse_colors(self):
+        config_path = FIXTURES_DIR / "alacritty" / "alacritty.toml"
+        ctec = AlacrittyAdapter.parse(config_path)
+
+        assert ctec.color_scheme is not None
+        assert ctec.color_scheme.foreground is not None
+        assert ctec.color_scheme.background is not None
+
+    def test_export_toml(self):
+        ctec = CTEC(
+            font=FontConfig(family="Monaco", size=13.0),
+            window=WindowConfig(columns=100, rows=30),
+        )
+        output = AlacrittyAdapter.export(ctec, use_toml=True)
+
+        assert "Monaco" in output
+        assert "columns = 100" in output
+
+    def test_export_yaml(self):
+        ctec = CTEC(
+            font=FontConfig(family="Monaco", size=13.0),
+        )
+        output = AlacrittyAdapter.export(ctec, use_toml=False)
+
+        assert "Monaco" in output
+        assert ":" in output  # YAML uses colons
+
+    def test_key_bindings(self):
+        config_path = FIXTURES_DIR / "alacritty" / "alacritty.toml"
+        ctec = AlacrittyAdapter.parse(config_path)
+
+        assert len(ctec.key_bindings) > 0
+        # Check for Copy binding
+        copy_binding = next(
+            (kb for kb in ctec.key_bindings if kb.action == "Copy"), None
+        )
+        assert copy_binding is not None
+
+
+class TestKittyAdapter:
+    """Tests for the Kitty adapter."""
+
+    def test_adapter_metadata(self):
+        assert KittyAdapter.name == "kitty"
+        assert ".conf" in KittyAdapter.config_extensions
+
+    def test_parse_fixture(self):
+        config_path = FIXTURES_DIR / "kitty" / "kitty.conf"
+        ctec = KittyAdapter.parse(config_path)
+
+        assert ctec.source_terminal == "kitty"
+        assert ctec.font.family == "JetBrains Mono"
+        assert ctec.font.size == 14.0
+        assert ctec.cursor.style == CursorStyle.BLOCK
+        assert ctec.window.columns == 120
+        assert ctec.window.rows == 40
+
+    def test_parse_colors(self):
+        config_path = FIXTURES_DIR / "kitty" / "kitty.conf"
+        ctec = KittyAdapter.parse(config_path)
+
+        assert ctec.color_scheme is not None
+        # Check foreground (#c5c8c6)
+        assert ctec.color_scheme.foreground.r == 197
+
+    def test_parse_behavior(self):
+        config_path = FIXTURES_DIR / "kitty" / "kitty.conf"
+        ctec = KittyAdapter.parse(config_path)
+
+        assert ctec.behavior is not None
+        assert ctec.behavior.shell == "/bin/zsh"
+        assert ctec.behavior.scrollback_lines == 10000
+        assert ctec.behavior.bell_mode == BellMode.VISUAL
+
+    def test_export(self):
+        ctec = CTEC(
+            font=FontConfig(family="Fira Code", size=12.0),
+            cursor=CursorConfig(style=CursorStyle.BEAM, blink=True),
+        )
+        output = KittyAdapter.export(ctec)
+
+        assert "font_family Fira Code" in output
+        assert "font_size 12.0" in output
+        assert "cursor_shape beam" in output
+
+    def test_key_bindings(self):
+        config_path = FIXTURES_DIR / "kitty" / "kitty.conf"
+        ctec = KittyAdapter.parse(config_path)
+
+        assert len(ctec.key_bindings) > 0
+
+    def test_terminal_specific_settings(self):
+        config_path = FIXTURES_DIR / "kitty" / "kitty.conf"
+        ctec = KittyAdapter.parse(config_path)
+
+        kitty_specific = ctec.get_terminal_specific("kitty")
+        assert len(kitty_specific) > 0
+
+
+class TestWeztermAdapter:
+    """Tests for the Wezterm adapter."""
+
+    def test_adapter_metadata(self):
+        assert WeztermAdapter.name == "wezterm"
+        assert ".lua" in WeztermAdapter.config_extensions
+
+    def test_parse_fixture(self):
+        config_path = FIXTURES_DIR / "wezterm" / "wezterm.lua"
+        ctec = WeztermAdapter.parse(config_path)
+
+        assert ctec.source_terminal == "wezterm"
+        assert ctec.font.family == "JetBrains Mono"
+        assert ctec.font.size == 14.0
+        assert ctec.window.columns == 120
+        assert ctec.window.rows == 40
+
+    def test_parse_colors(self):
+        config_path = FIXTURES_DIR / "wezterm" / "wezterm.lua"
+        ctec = WeztermAdapter.parse(config_path)
+
+        assert ctec.color_scheme is not None
+        # Wezterm parsing may have warnings about Lua complexity
+        assert len(ctec.warnings) > 0  # Expected warning about Lua
+
+    def test_parse_cursor(self):
+        config_path = FIXTURES_DIR / "wezterm" / "wezterm.lua"
+        ctec = WeztermAdapter.parse(config_path)
+
+        assert ctec.cursor is not None
+        assert ctec.cursor.style == CursorStyle.BLOCK
+        assert ctec.cursor.blink is True
+
+    def test_export(self):
+        ctec = CTEC(
+            font=FontConfig(family="Fira Code", size=12.0),
+            cursor=CursorConfig(style=CursorStyle.BEAM, blink=False),
+        )
+        output = WeztermAdapter.export(ctec)
+
+        assert 'wezterm.font("Fira Code")' in output
+        assert "font_size = 12.0" in output
+        assert "SteadyBar" in output
+
+    def test_export_colors(self):
+        ctec = CTEC(
+            color_scheme=ColorScheme(
+                foreground=Color(255, 255, 255),
+                background=Color(0, 0, 0),
+            )
+        )
+        output = WeztermAdapter.export(ctec)
+
+        assert 'foreground = "#ffffff"' in output
+        assert 'background = "#000000"' in output
+
+    def test_export_valid_lua(self):
+        """Verify the exported Lua is syntactically valid."""
+        ctec = CTEC(
+            font=FontConfig(family="Test", size=12.0),
+            window=WindowConfig(columns=80, rows=24),
+        )
+        output = WeztermAdapter.export(ctec)
+
+        # Should have required Lua structure
+        assert "local wezterm = require 'wezterm'" in output
+        assert "local config = wezterm.config_builder()" in output
+        assert "return config" in output
+
+
+class TestITerm2Adapter:
+    """Tests for the iTerm2 adapter."""
+
+    def test_adapter_metadata(self):
+        assert ITerm2Adapter.name == "iterm2"
+        assert ".plist" in ITerm2Adapter.config_extensions
+
+    def test_parse_fixture(self):
+        config_path = FIXTURES_DIR / "iterm2" / "com.googlecode.iterm2.plist"
+        ctec = ITerm2Adapter.parse(config_path)
+
+        assert ctec.source_terminal == "iterm2"
+        assert ctec.window.columns == 120
+        assert ctec.window.rows == 40
+
+    def test_parse_profiles(self):
+        config_path = FIXTURES_DIR / "iterm2" / "com.googlecode.iterm2.plist"
+        ctec = ITerm2Adapter.parse(config_path)
+
+        assert len(ctec.profiles) > 0
+        default_profile = next(p for p in ctec.profiles if p.is_default)
+        assert default_profile.name == "Default"
+
+    def test_parse_colors(self):
+        config_path = FIXTURES_DIR / "iterm2" / "com.googlecode.iterm2.plist"
+        ctec = ITerm2Adapter.parse(config_path)
+
+        assert ctec.color_scheme is not None
+        assert ctec.color_scheme.foreground is not None
+
+    def test_export(self):
+        ctec = CTEC(
+            font=FontConfig(family="Monaco", size=12.0),
+            cursor=CursorConfig(style=CursorStyle.BLOCK, blink=True),
+            color_scheme=ColorScheme(
+                foreground=Color(255, 255, 255),
+                background=Color(0, 0, 0),
+            ),
+        )
+        output = ITerm2Adapter.export(ctec)
+
+        # Should be valid plist XML
+        assert '<?xml version="1.0"' in output
+        assert "<plist" in output
+        assert "Monaco" in output
+
+    def test_terminal_specific_settings(self):
+        config_path = FIXTURES_DIR / "iterm2" / "com.googlecode.iterm2.plist"
+        ctec = ITerm2Adapter.parse(config_path)
+
+        iterm_specific = ctec.get_terminal_specific("iterm2")
+        assert len(iterm_specific) > 0
+
+
+class TestCrossTerminalConversion:
+    """Tests for converting between different terminals."""
+
+    def test_ghostty_to_alacritty(self):
+        # Parse Ghostty config
+        ghostty_path = FIXTURES_DIR / "ghostty" / "config"
+        ctec = GhosttyAdapter.parse(ghostty_path)
+
+        # Export to Alacritty
+        alacritty_output = AlacrittyAdapter.export(ctec)
+
+        # Re-parse as Alacritty
+        alacritty_ctec = AlacrittyAdapter.parse("test.toml", content=alacritty_output)
+
+        # Core settings should be preserved
+        assert alacritty_ctec.font.family == ctec.font.family
+        assert alacritty_ctec.font.size == ctec.font.size
+
+    def test_kitty_to_ghostty(self):
+        # Parse Kitty config
+        kitty_path = FIXTURES_DIR / "kitty" / "kitty.conf"
+        ctec = KittyAdapter.parse(kitty_path)
+
+        # Export to Ghostty
+        ghostty_output = GhosttyAdapter.export(ctec)
+
+        # Re-parse as Ghostty
+        ghostty_ctec = GhosttyAdapter.parse("test", content=ghostty_output)
+
+        # Core settings should be preserved
+        assert ghostty_ctec.font.family == ctec.font.family
+        assert ghostty_ctec.font.size == ctec.font.size
+
+    def test_alacritty_to_kitty(self):
+        # Parse Alacritty config
+        alacritty_path = FIXTURES_DIR / "alacritty" / "alacritty.toml"
+        ctec = AlacrittyAdapter.parse(alacritty_path)
+
+        # Export to Kitty
+        kitty_output = KittyAdapter.export(ctec)
+
+        # Re-parse as Kitty
+        kitty_ctec = KittyAdapter.parse("test.conf", content=kitty_output)
+
+        # Core settings should be preserved
+        assert kitty_ctec.font.family == ctec.font.family
+
+    def test_color_preservation_across_terminals(self):
+        """Test that colors are preserved when converting between terminals."""
+        # Start with a known color scheme
+        original = CTEC(
+            color_scheme=ColorScheme(
+                foreground=Color(197, 200, 198),
+                background=Color(29, 31, 33),
+                red=Color(204, 102, 102),
+            )
+        )
+
+        # Convert through all terminals
+        ghostty_output = GhosttyAdapter.export(original)
+        ghostty_ctec = GhosttyAdapter.parse("test", content=ghostty_output)
+
+        # Colors should be preserved
+        assert ghostty_ctec.color_scheme.foreground.r == 197
+        assert ghostty_ctec.color_scheme.foreground.g == 200
+        assert ghostty_ctec.color_scheme.foreground.b == 198


### PR DESCRIPTION
Add CTEC (Common Terminal Emulator Configuration) format for portable terminal settings across different terminal emulators.

Features:
- CTEC data model for common terminal settings (colors, fonts, cursor, window, behavior, key bindings, profiles)
- Support for TOML, JSON, and YAML serialization
- Terminal adapters for iTerm2, Ghostty, Alacritty, Kitty, and Wezterm
- CLI commands: export, import, convert, list, info
- Incompatibility reporting for non-portable settings
- Terminal-specific setting preservation

The CLI enables users to export their terminal configuration from one emulator and import it into another, making it easy to try different terminals while preserving their preferred settings.