### PR TITLE
Add ruff linting/formatting and lefthook pre-commit hooks

### DIFF
--- a/console_cowboy/cli.py
+++ b/console_cowboy/cli.py
@@ -12,18 +12,15 @@ Commands:
     convert: Convert directly between terminal configuration formats
 """
 
-import sys
 from pathlib import Path
-from typing import Optional
 
 import click
 
+# Import to trigger registration
+import console_cowboy.terminals  # noqa: F401
 from console_cowboy.ctec import CTEC, CTECSerializer
 from console_cowboy.ctec.serializers import OutputFormat
 from console_cowboy.terminals import TerminalRegistry
-
-# Import to trigger registration
-import console_cowboy.terminals  # noqa: F401
 
 
 def get_terminal_choices() -> list[str]:
@@ -50,7 +47,9 @@ def print_terminal_specific(ctec: CTEC) -> None:
         )
         for setting in ctec.terminal_specific:
             click.echo(
-                click.style(f"  [{setting.terminal}] {setting.key} = {setting.value}", fg="cyan"),
+                click.style(
+                    f"  [{setting.terminal}] {setting.key} = {setting.value}", fg="cyan"
+                ),
                 err=True,
             )
 
@@ -149,10 +148,10 @@ def list_terminals():
 )
 def export_config(
     terminal: str,
-    input_path: Optional[Path],
-    output_path: Optional[Path],
+    input_path: Path | None,
+    output_path: Path | None,
     output_format: str,
-    profile_name: Optional[str],
+    profile_name: str | None,
     quiet: bool,
 ):
     """
@@ -268,8 +267,8 @@ def export_config(
 def import_config(
     input_file: Path,
     terminal: str,
-    output_path: Optional[Path],
-    input_format: Optional[str],
+    output_path: Path | None,
+    input_format: str | None,
     quiet: bool,
 ):
     """
@@ -301,8 +300,7 @@ def import_config(
             fmt = CTECSerializer.detect_format(input_file)
         except ValueError:
             raise click.ClickException(
-                f"Cannot detect format from extension. "
-                f"Please specify with -f/--format."
+                "Cannot detect format from extension. Please specify with -f/--format."
             )
 
     # Parse CTEC configuration
@@ -390,8 +388,8 @@ def convert_config(
     input_file: Path,
     from_terminal: str,
     to_terminal: str,
-    output_path: Optional[Path],
-    profile_name: Optional[str],
+    output_path: Path | None,
+    profile_name: str | None,
     quiet: bool,
 ):
     """
@@ -490,7 +488,7 @@ def convert_config(
     type=click.Choice(get_terminal_choices(), case_sensitive=False),
     help="Terminal type (if parsing native config). If not specified, assumes CTEC format.",
 )
-def show_info(input_file: Path, terminal: Optional[str]):
+def show_info(input_file: Path, terminal: str | None):
     """
     Display information about a configuration file.
 

--- a/console_cowboy/ctec/__init__.py
+++ b/console_cowboy/ctec/__init__.py
@@ -7,22 +7,22 @@ migration of settings between different terminal applications.
 
 from .schema import (
     CTEC,
-    ColorScheme,
-    ColorVariant,
-    Color,
-    FontConfig,
-    FontWeight,
-    FontStyle,
-    CursorConfig,
-    CursorStyle,
-    WindowConfig,
     BehaviorConfig,
     BellMode,
-    ScrollConfig,
+    Color,
+    ColorScheme,
+    ColorVariant,
+    CursorConfig,
+    CursorStyle,
+    FontConfig,
+    FontStyle,
+    FontWeight,
     KeyBinding,
+    ScrollConfig,
     TerminalSpecificSetting,
+    WindowConfig,
 )
-from .serializers import CTECSerializer, OutputFormat, CTEC_JSON_SCHEMA
+from .serializers import CTEC_JSON_SCHEMA, CTECSerializer, OutputFormat
 
 __all__ = [
     "CTEC",

--- a/console_cowboy/ctec/schema.py
+++ b/console_cowboy/ctec/schema.py
@@ -7,7 +7,6 @@ intermediate representation for terminal emulator settings.
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional
 
 
 class CursorStyle(Enum):
@@ -125,7 +124,9 @@ class Color:
     def __post_init__(self) -> None:
         for component, name in [(self.r, "r"), (self.g, "g"), (self.b, "b")]:
             if not 0 <= component <= 255:
-                raise ValueError(f"Color component {name} must be 0-255, got {component}")
+                raise ValueError(
+                    f"Color component {name} must be 0-255, got {component}"
+                )
 
     def to_hex(self) -> str:
         """Convert to hex color string (e.g., '#ff0000')."""
@@ -199,43 +200,43 @@ class ColorScheme:
     """
 
     # Metadata
-    name: Optional[str] = None
-    author: Optional[str] = None
-    variant: Optional[ColorVariant] = None
+    name: str | None = None
+    author: str | None = None
+    variant: ColorVariant | None = None
 
     # Core semantic colors (Gogh base format)
-    foreground: Optional[Color] = None
-    background: Optional[Color] = None
-    cursor: Optional[Color] = None
+    foreground: Color | None = None
+    background: Color | None = None
+    cursor: Color | None = None
 
     # Extended semantic colors (iTerm2-Color-Schemes YAML extensions)
-    cursor_text: Optional[Color] = None
-    selection: Optional[Color] = None
-    selection_text: Optional[Color] = None
-    bold: Optional[Color] = None
-    link: Optional[Color] = None
-    underline: Optional[Color] = None
-    cursor_guide: Optional[Color] = None
+    cursor_text: Color | None = None
+    selection: Color | None = None
+    selection_text: Color | None = None
+    bold: Color | None = None
+    link: Color | None = None
+    underline: Color | None = None
+    cursor_guide: Color | None = None
 
     # Normal colors (0-7)
-    black: Optional[Color] = None
-    red: Optional[Color] = None
-    green: Optional[Color] = None
-    yellow: Optional[Color] = None
-    blue: Optional[Color] = None
-    magenta: Optional[Color] = None
-    cyan: Optional[Color] = None
-    white: Optional[Color] = None
+    black: Color | None = None
+    red: Color | None = None
+    green: Color | None = None
+    yellow: Color | None = None
+    blue: Color | None = None
+    magenta: Color | None = None
+    cyan: Color | None = None
+    white: Color | None = None
 
     # Bright colors (8-15)
-    bright_black: Optional[Color] = None
-    bright_red: Optional[Color] = None
-    bright_green: Optional[Color] = None
-    bright_yellow: Optional[Color] = None
-    bright_blue: Optional[Color] = None
-    bright_magenta: Optional[Color] = None
-    bright_cyan: Optional[Color] = None
-    bright_white: Optional[Color] = None
+    bright_black: Color | None = None
+    bright_red: Color | None = None
+    bright_green: Color | None = None
+    bright_yellow: Color | None = None
+    bright_blue: Color | None = None
+    bright_magenta: Color | None = None
+    bright_cyan: Color | None = None
+    bright_white: Color | None = None
 
     # All color field names for iteration
     _COLOR_FIELDS = [
@@ -332,23 +333,23 @@ class FontConfig:
         _source_names: Original font names from source terminal (for round-trip)
     """
 
-    family: Optional[str] = None
-    size: Optional[float] = None
-    line_height: Optional[float] = None
-    cell_width: Optional[float] = None
-    weight: Optional[FontWeight] = None
-    style: Optional[FontStyle] = None
-    bold_font: Optional[str] = None
-    italic_font: Optional[str] = None
-    bold_italic_font: Optional[str] = None
-    ligatures: Optional[bool] = None
-    anti_aliasing: Optional[bool] = None
-    fallback_fonts: Optional[list[str]] = None
-    symbol_map: Optional[dict[str, str]] = None
-    draw_powerline_glyphs: Optional[bool] = None
-    box_drawing_scale: Optional[float] = None
+    family: str | None = None
+    size: float | None = None
+    line_height: float | None = None
+    cell_width: float | None = None
+    weight: FontWeight | None = None
+    style: FontStyle | None = None
+    bold_font: str | None = None
+    italic_font: str | None = None
+    bold_italic_font: str | None = None
+    ligatures: bool | None = None
+    anti_aliasing: bool | None = None
+    fallback_fonts: list[str] | None = None
+    symbol_map: dict[str, str] | None = None
+    draw_powerline_glyphs: bool | None = None
+    box_drawing_scale: float | None = None
     # Internal: preserve original names for lossless round-trips
-    _source_names: Optional[dict[str, str]] = field(default=None, repr=False)
+    _source_names: dict[str, str] | None = field(default=None, repr=False)
 
     def to_dict(self) -> dict:
         """Convert to dictionary representation."""
@@ -423,7 +424,7 @@ class FontConfig:
             self._source_names = {}
         self._source_names[terminal] = name
 
-    def get_source_name(self, terminal: str) -> Optional[str]:
+    def get_source_name(self, terminal: str) -> str | None:
         """Get the original font name for a specific terminal."""
         if self._source_names is None:
             return None
@@ -441,9 +442,9 @@ class CursorConfig:
         blink_interval: Blink interval in milliseconds
     """
 
-    style: Optional[CursorStyle] = None
-    blink: Optional[bool] = None
-    blink_interval: Optional[int] = None
+    style: CursorStyle | None = None
+    blink: bool | None = None
+    blink_interval: int | None = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary representation."""
@@ -483,15 +484,15 @@ class WindowConfig:
         dynamic_title: Whether to update window title from shell
     """
 
-    columns: Optional[int] = None
-    rows: Optional[int] = None
-    opacity: Optional[float] = None
-    blur: Optional[int] = None
-    padding_horizontal: Optional[int] = None
-    padding_vertical: Optional[int] = None
-    decorations: Optional[bool] = None
-    startup_mode: Optional[str] = None
-    dynamic_title: Optional[bool] = None
+    columns: int | None = None
+    rows: int | None = None
+    opacity: float | None = None
+    blur: int | None = None
+    padding_horizontal: int | None = None
+    padding_vertical: int | None = None
+    decorations: bool | None = None
+    startup_mode: str | None = None
+    dynamic_title: bool | None = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary representation."""
@@ -561,10 +562,10 @@ class ScrollConfig:
         multiplier: Scroll speed multiplier (1.0 = normal, higher = faster)
     """
 
-    unlimited: Optional[bool] = None
-    disabled: Optional[bool] = None
-    lines: Optional[int] = None
-    multiplier: Optional[float] = None
+    unlimited: bool | None = None
+    disabled: bool | None = None
+    lines: int | None = None
+    multiplier: float | None = None
 
     def get_effective_lines(self, default: int = 10000, max_lines: int = 100000) -> int:
         """
@@ -681,14 +682,14 @@ class BehaviorConfig:
         close_on_exit: Action when shell exits ('close', 'hold', 'restart')
     """
 
-    shell: Optional[str] = None
-    working_directory: Optional[str] = None
-    scrollback_lines: Optional[int] = None  # DEPRECATED: use CTEC.scroll
-    mouse_enabled: Optional[bool] = None
-    bell_mode: Optional[BellMode] = None
-    copy_on_select: Optional[bool] = None
-    confirm_close: Optional[bool] = None
-    close_on_exit: Optional[str] = None
+    shell: str | None = None
+    working_directory: str | None = None
+    scrollback_lines: int | None = None  # DEPRECATED: use CTEC.scroll
+    mouse_enabled: bool | None = None
+    bell_mode: BellMode | None = None
+    copy_on_select: bool | None = None
+    confirm_close: bool | None = None
+    close_on_exit: str | None = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary representation."""
@@ -806,13 +807,13 @@ class CTEC:
     """
 
     version: str = "1.0"
-    source_terminal: Optional[str] = None
-    color_scheme: Optional[ColorScheme] = None
-    font: Optional[FontConfig] = None
-    cursor: Optional[CursorConfig] = None
-    window: Optional[WindowConfig] = None
-    behavior: Optional[BehaviorConfig] = None
-    scroll: Optional[ScrollConfig] = None
+    source_terminal: str | None = None
+    color_scheme: ColorScheme | None = None
+    font: FontConfig | None = None
+    cursor: CursorConfig | None = None
+    window: WindowConfig | None = None
+    behavior: BehaviorConfig | None = None
+    scroll: ScrollConfig | None = None
     key_bindings: list[KeyBinding] = field(default_factory=list)
     terminal_specific: list[TerminalSpecificSetting] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
@@ -837,7 +838,9 @@ class CTEC:
         if self.key_bindings:
             result["key_bindings"] = [kb.to_dict() for kb in self.key_bindings]
         if self.terminal_specific:
-            result["terminal_specific"] = [ts.to_dict() for ts in self.terminal_specific]
+            result["terminal_specific"] = [
+                ts.to_dict() for ts in self.terminal_specific
+            ]
         return result
 
     @classmethod
@@ -855,10 +858,10 @@ class CTEC:
             behavior=BehaviorConfig.from_dict(data["behavior"])
             if "behavior" in data
             else None,
-            scroll=ScrollConfig.from_dict(data["scroll"])
-            if "scroll" in data
-            else None,
-            key_bindings=[KeyBinding.from_dict(kb) for kb in data.get("key_bindings", [])],
+            scroll=ScrollConfig.from_dict(data["scroll"]) if "scroll" in data else None,
+            key_bindings=[
+                KeyBinding.from_dict(kb) for kb in data.get("key_bindings", [])
+            ],
             terminal_specific=[
                 TerminalSpecificSetting.from_dict(ts)
                 for ts in data.get("terminal_specific", [])
@@ -870,9 +873,7 @@ class CTEC:
         """Add a compatibility warning."""
         self.warnings.append(warning)
 
-    def add_terminal_specific(
-        self, terminal: str, key: str, value: object
-    ) -> None:
+    def add_terminal_specific(self, terminal: str, key: str, value: object) -> None:
         """Add a terminal-specific setting."""
         self.terminal_specific.append(
             TerminalSpecificSetting(terminal=terminal, key=key, value=value)

--- a/console_cowboy/ctec/serializers.py
+++ b/console_cowboy/ctec/serializers.py
@@ -8,7 +8,7 @@ JSON is supported for programmatic use and editor validation via JSON Schema.
 import json
 from enum import Enum
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 import yaml
 
@@ -212,12 +212,28 @@ CTEC_JSON_SCHEMA: dict[str, Any] = {
             "properties": {
                 "family": {"type": "string", "description": "Primary font family"},
                 "size": {"type": "number", "description": "Font size in points"},
-                "line_height": {"type": "number", "description": "Line height multiplier"},
-                "cell_width": {"type": "number", "description": "Cell width multiplier"},
+                "line_height": {
+                    "type": "number",
+                    "description": "Line height multiplier",
+                },
+                "cell_width": {
+                    "type": "number",
+                    "description": "Cell width multiplier",
+                },
                 "weight": {
                     "type": "string",
                     "description": "Font weight",
-                    "enum": ["thin", "extralight", "light", "regular", "medium", "semibold", "bold", "extrabold", "black"],
+                    "enum": [
+                        "thin",
+                        "extralight",
+                        "light",
+                        "regular",
+                        "medium",
+                        "semibold",
+                        "bold",
+                        "extrabold",
+                        "black",
+                    ],
                 },
                 "style": {
                     "type": "string",
@@ -229,7 +245,10 @@ CTEC_JSON_SCHEMA: dict[str, Any] = {
                 "ligatures": {"type": "boolean"},
                 "anti_aliasing": {"type": "boolean"},
                 "fallback_fonts": {"type": "array", "items": {"type": "string"}},
-                "symbol_map": {"type": "object", "additionalProperties": {"type": "string"}},
+                "symbol_map": {
+                    "type": "object",
+                    "additionalProperties": {"type": "string"},
+                },
                 "draw_powerline_glyphs": {"type": "boolean"},
                 "box_drawing_scale": {"type": "number"},
             },
@@ -278,7 +297,10 @@ CTEC_JSON_SCHEMA: dict[str, Any] = {
                 "bell_mode": {"type": "string", "enum": ["none", "audible", "visual"]},
                 "copy_on_select": {"type": "boolean"},
                 "confirm_close": {"type": "boolean"},
-                "close_on_exit": {"type": "string", "enum": ["close", "hold", "restart"]},
+                "close_on_exit": {
+                    "type": "string",
+                    "enum": ["close", "hold", "restart"],
+                },
             },
             "additionalProperties": False,
         },
@@ -454,7 +476,7 @@ class CTECSerializer:
             raise ValueError(f"Unsupported format: {format}")
 
     @staticmethod
-    def detect_format(path: Union[str, Path]) -> OutputFormat:
+    def detect_format(path: str | Path) -> OutputFormat:
         """
         Detect the format based on file extension.
 
@@ -480,7 +502,7 @@ class CTECSerializer:
             )
 
     @staticmethod
-    def read_file(path: Union[str, Path], format: OutputFormat = None) -> CTEC:
+    def read_file(path: str | Path, format: OutputFormat = None) -> CTEC:
         """
         Read CTEC from a file.
 
@@ -498,9 +520,7 @@ class CTECSerializer:
         return CTECSerializer.deserialize(content, format)
 
     @staticmethod
-    def write_file(
-        ctec: CTEC, path: Union[str, Path], format: OutputFormat = None
-    ) -> None:
+    def write_file(ctec: CTEC, path: str | Path, format: OutputFormat = None) -> None:
         """
         Write CTEC to a file.
 
@@ -548,7 +568,7 @@ class CTECSerializer:
         return ITERM2_COLOR_SCHEME_SCHEMA
 
     @staticmethod
-    def write_json_schema(path: Union[str, Path], bundled: bool = True) -> None:
+    def write_json_schema(path: str | Path, bundled: bool = True) -> None:
         """
         Write the JSON Schema to a file.
 
@@ -562,7 +582,7 @@ class CTECSerializer:
         path.write_text(content)
 
     @staticmethod
-    def write_color_scheme_schema(path: Union[str, Path]) -> None:
+    def write_color_scheme_schema(path: str | Path) -> None:
         """
         Write the standalone color scheme JSON Schema to a file.
 

--- a/console_cowboy/terminals/__init__.py
+++ b/console_cowboy/terminals/__init__.py
@@ -5,10 +5,10 @@ This module provides classes for reading and writing configuration files
 for various terminal emulators.
 """
 
-from .base import TerminalAdapter, TerminalRegistry
-from .iterm2 import ITerm2Adapter
-from .ghostty import GhosttyAdapter
 from .alacritty import AlacrittyAdapter
+from .base import TerminalAdapter, TerminalRegistry
+from .ghostty import GhosttyAdapter
+from .iterm2 import ITerm2Adapter
 from .kitty import KittyAdapter
 from .wezterm import WeztermAdapter
 

--- a/console_cowboy/terminals/base.py
+++ b/console_cowboy/terminals/base.py
@@ -7,7 +7,6 @@ methods to parse (import) and export configurations to/from CTEC format.
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Optional, Union
 
 from console_cowboy.ctec.schema import CTEC
 
@@ -41,9 +40,9 @@ class TerminalAdapter(ABC):
     @abstractmethod
     def parse(
         cls,
-        source: Union[str, Path],
+        source: str | Path,
         *,
-        content: Optional[str] = None,
+        content: str | None = None,
     ) -> CTEC:
         """
         Parse a terminal configuration file into CTEC format.
@@ -76,7 +75,7 @@ class TerminalAdapter(ABC):
         pass
 
     @classmethod
-    def get_default_config_path(cls) -> Optional[Path]:
+    def get_default_config_path(cls) -> Path | None:
         """
         Get the default configuration file path for this terminal.
 
@@ -91,7 +90,7 @@ class TerminalAdapter(ABC):
         return None
 
     @classmethod
-    def write_config(cls, ctec: CTEC, path: Union[str, Path]) -> None:
+    def write_config(cls, ctec: CTEC, path: str | Path) -> None:
         """
         Export and write CTEC configuration to a file.
 
@@ -121,7 +120,7 @@ class TerminalRegistry:
         cls._adapters[adapter.name] = adapter
 
     @classmethod
-    def get(cls, name: str) -> Optional[type[TerminalAdapter]]:
+    def get(cls, name: str) -> type[TerminalAdapter] | None:
         """
         Get a terminal adapter by name.
 

--- a/console_cowboy/terminals/ghostty.py
+++ b/console_cowboy/terminals/ghostty.py
@@ -6,12 +6,10 @@ Ghostty uses a simple key=value configuration format stored in
 """
 
 from pathlib import Path
-from typing import Optional, Union
 
 from console_cowboy.ctec.schema import (
     CTEC,
     BehaviorConfig,
-    BellMode,
     ColorScheme,
     CursorConfig,
     CursorStyle,
@@ -88,9 +86,9 @@ class GhosttyAdapter(TerminalAdapter):
     @classmethod
     def parse(
         cls,
-        source: Union[str, Path],
+        source: str | Path,
         *,
-        content: Optional[str] = None,
+        content: str | None = None,
     ) -> CTEC:
         """Parse a Ghostty configuration file."""
         ctec = CTEC(source_terminal="ghostty")
@@ -171,7 +169,9 @@ class GhosttyAdapter(TerminalAdapter):
 
             # Parse cursor settings
             elif key == "cursor-style":
-                cursor.style = cls.CURSOR_STYLE_MAP.get(value.lower(), CursorStyle.BLOCK)
+                cursor.style = cls.CURSOR_STYLE_MAP.get(
+                    value.lower(), CursorStyle.BLOCK
+                )
             elif key == "cursor-style-blink":
                 cursor.blink = value.lower() == "true"
 
@@ -366,7 +366,9 @@ class GhosttyAdapter(TerminalAdapter):
             if ctec.window.startup_mode == "fullscreen":
                 lines.append("fullscreen = true")
             if ctec.window.dynamic_title is not None:
-                lines.append(f"window-title-show-all = {str(ctec.window.dynamic_title).lower()}")
+                lines.append(
+                    f"window-title-show-all = {str(ctec.window.dynamic_title).lower()}"
+                )
             lines.append("")
 
         # Export behavior settings
@@ -377,9 +379,13 @@ class GhosttyAdapter(TerminalAdapter):
             if ctec.behavior.working_directory:
                 lines.append(f"working-directory = {ctec.behavior.working_directory}")
             if ctec.behavior.copy_on_select is not None:
-                lines.append(f"copy-on-select = {str(ctec.behavior.copy_on_select).lower()}")
+                lines.append(
+                    f"copy-on-select = {str(ctec.behavior.copy_on_select).lower()}"
+                )
             if ctec.behavior.confirm_close is not None:
-                lines.append(f"confirm-close-surface = {str(ctec.behavior.confirm_close).lower()}")
+                lines.append(
+                    f"confirm-close-surface = {str(ctec.behavior.confirm_close).lower()}"
+                )
             lines.append("")
 
         # Export scroll settings (Ghostty uses bytes, not lines)

--- a/console_cowboy/terminals/iterm2.py
+++ b/console_cowboy/terminals/iterm2.py
@@ -9,7 +9,6 @@ Color schemes can also be stored as separate .itermcolors files.
 
 import plistlib
 from pathlib import Path
-from typing import Optional, Union
 
 from console_cowboy.ctec.schema import (
     CTEC,
@@ -20,15 +19,14 @@ from console_cowboy.ctec.schema import (
     CursorConfig,
     CursorStyle,
     FontConfig,
-    KeyBinding,
     ScrollConfig,
     WindowConfig,
 )
 from console_cowboy.utils.colors import color_to_float_tuple, float_tuple_to_color
 from console_cowboy.utils.fonts import (
+    friendly_to_postscript,
     is_postscript_name,
     postscript_to_friendly,
-    friendly_to_postscript,
 )
 
 from .base import TerminalAdapter
@@ -132,8 +130,6 @@ class ITerm2Adapter(TerminalAdapter):
     @classmethod
     def _parse_profile_into_ctec(cls, profile_data: dict, ctec: CTEC) -> None:
         """Parse an iTerm2 profile's settings directly into a CTEC object."""
-        name = profile_data.get("Name", "Default")
-
         # Parse color scheme
         ctec.color_scheme = cls._parse_color_scheme(profile_data)
 
@@ -144,7 +140,9 @@ class ITerm2Adapter(TerminalAdapter):
             parts = font_str.rsplit(" ", 1)
             if len(parts) == 2:
                 font_family = parts[0]
-                font_size = float(parts[1]) if parts[1].replace(".", "").isdigit() else None
+                font_size = (
+                    float(parts[1]) if parts[1].replace(".", "").isdigit() else None
+                )
             else:
                 font_family = font_str
                 font_size = None
@@ -158,7 +156,9 @@ class ITerm2Adapter(TerminalAdapter):
                 ctec.font = FontConfig(family=font_family, size=font_size)
 
         # Handle Non-ASCII Font as fallback font
-        if "Non-ASCII Font" in profile_data and profile_data.get("Use Non-ASCII Font", False):
+        if "Non-ASCII Font" in profile_data and profile_data.get(
+            "Use Non-ASCII Font", False
+        ):
             non_ascii_str = profile_data["Non-ASCII Font"]
             non_ascii_parts = non_ascii_str.rsplit(" ", 1)
             non_ascii_family = non_ascii_parts[0] if non_ascii_parts else non_ascii_str
@@ -185,13 +185,17 @@ class ITerm2Adapter(TerminalAdapter):
             if ctec.font:
                 ctec.font.draw_powerline_glyphs = profile_data["Draw Powerline Glyphs"]
             else:
-                ctec.font = FontConfig(draw_powerline_glyphs=profile_data["Draw Powerline Glyphs"])
+                ctec.font = FontConfig(
+                    draw_powerline_glyphs=profile_data["Draw Powerline Glyphs"]
+                )
 
         # Parse cursor configuration
         cursor_config = CursorConfig()
         if "Cursor Type" in profile_data:
             cursor_type = profile_data["Cursor Type"]
-            cursor_config.style = cls.CURSOR_STYLE_MAP.get(cursor_type, CursorStyle.BLOCK)
+            cursor_config.style = cls.CURSOR_STYLE_MAP.get(
+                cursor_type, CursorStyle.BLOCK
+            )
         if "Blinking Cursor" in profile_data:
             cursor_config.blink = profile_data["Blinking Cursor"]
         ctec.cursor = cursor_config
@@ -298,10 +302,10 @@ class ITerm2Adapter(TerminalAdapter):
     @classmethod
     def parse(
         cls,
-        source: Union[str, Path],
+        source: str | Path,
         *,
-        content: Optional[str] = None,
-        profile_name: Optional[str] = None,
+        content: str | None = None,
+        profile_name: str | None = None,
     ) -> CTEC:
         """
         Parse an iTerm2 configuration file.
@@ -344,7 +348,9 @@ class ITerm2Adapter(TerminalAdapter):
                 return ctec
 
             # Build list of profile names and find default
-            profile_names = [p.get("Name", f"Profile {i}") for i, p in enumerate(profiles)]
+            profile_names = [
+                p.get("Name", f"Profile {i}") for i, p in enumerate(profiles)
+            ]
             default_profile_data = None
             default_profile_name = None
 
@@ -382,7 +388,9 @@ class ITerm2Adapter(TerminalAdapter):
 
                 # Warn if multiple profiles exist
                 if len(profiles) > 1:
-                    other_profiles = [n for n in profile_names if n != selected_profile_name]
+                    other_profiles = [
+                        n for n in profile_names if n != selected_profile_name
+                    ]
                     ctec.add_warning(
                         f"iTerm2 config contains {len(profiles)} profiles. "
                         f"Importing '{selected_profile_name}' (default). "
@@ -467,7 +475,9 @@ class ITerm2Adapter(TerminalAdapter):
         # Export cursor
         if ctec.cursor:
             if ctec.cursor.style:
-                result["Cursor Type"] = cls.CURSOR_STYLE_REVERSE_MAP.get(ctec.cursor.style, 1)
+                result["Cursor Type"] = cls.CURSOR_STYLE_REVERSE_MAP.get(
+                    ctec.cursor.style, 1
+                )
             if ctec.cursor.blink is not None:
                 result["Blinking Cursor"] = ctec.cursor.blink
 

--- a/console_cowboy/terminals/kitty.py
+++ b/console_cowboy/terminals/kitty.py
@@ -6,7 +6,6 @@ Kitty uses a simple key-value configuration format stored in
 """
 
 from pathlib import Path
-from typing import Optional, Union
 
 from console_cowboy.ctec.schema import (
     CTEC,
@@ -80,9 +79,9 @@ class KittyAdapter(TerminalAdapter):
     @classmethod
     def parse(
         cls,
-        source: Union[str, Path],
+        source: str | Path,
         *,
-        content: Optional[str] = None,
+        content: str | None = None,
     ) -> CTEC:
         """Parse a Kitty configuration file."""
         ctec = CTEC(source_terminal="kitty")
@@ -167,7 +166,9 @@ class KittyAdapter(TerminalAdapter):
 
             # Parse cursor settings
             elif key == "cursor_shape":
-                cursor.style = cls.CURSOR_STYLE_MAP.get(value.lower(), CursorStyle.BLOCK)
+                cursor.style = cls.CURSOR_STYLE_MAP.get(
+                    value.lower(), CursorStyle.BLOCK
+                )
             elif key == "cursor_blink_interval":
                 try:
                     interval = float(value)

--- a/console_cowboy/utils/__init__.py
+++ b/console_cowboy/utils/__init__.py
@@ -2,6 +2,6 @@
 Utility modules for console-cowboy.
 """
 
-from .colors import normalize_color, color_to_float_tuple, float_tuple_to_color
+from .colors import color_to_float_tuple, float_tuple_to_color, normalize_color
 
 __all__ = ["normalize_color", "color_to_float_tuple", "float_tuple_to_color"]

--- a/console_cowboy/utils/colors.py
+++ b/console_cowboy/utils/colors.py
@@ -10,12 +10,10 @@ Different terminal emulators use different color representations:
 This module provides utilities for converting between these formats.
 """
 
-from typing import Tuple, Union
-
 from console_cowboy.ctec.schema import Color
 
 
-def normalize_color(value: Union[str, dict, tuple, list, Color]) -> Color:
+def normalize_color(value: str | dict | tuple | list | Color) -> Color:
     """
     Normalize a color value from various formats to a Color object.
 
@@ -64,7 +62,7 @@ def normalize_color(value: Union[str, dict, tuple, list, Color]) -> Color:
     raise ValueError(f"Unsupported color format: {type(value)}")
 
 
-def color_to_float_tuple(color: Color) -> Tuple[float, float, float]:
+def color_to_float_tuple(color: Color) -> tuple[float, float, float]:
     """
     Convert a Color to a tuple of floats (0.0-1.0).
 
@@ -79,7 +77,7 @@ def color_to_float_tuple(color: Color) -> Tuple[float, float, float]:
     return (color.r / 255.0, color.g / 255.0, color.b / 255.0)
 
 
-def float_tuple_to_color(values: Tuple[float, float, float]) -> Color:
+def float_tuple_to_color(values: tuple[float, float, float]) -> Color:
     """
     Convert a tuple of floats (0.0-1.0) to a Color.
 

--- a/console_cowboy/utils/fonts.py
+++ b/console_cowboy/utils/fonts.py
@@ -10,7 +10,6 @@ like Wezterm prefer friendly names.
 """
 
 import re
-from typing import Optional
 
 
 def postscript_to_friendly(postscript_name: str) -> str:
@@ -35,51 +34,62 @@ def postscript_to_friendly(postscript_name: str) -> str:
     # Remove common weight/style suffixes
     name = postscript_name
     suffixes_to_remove = [
-        '-Regular', '-Bold', '-Italic', '-BoldItalic',
-        '-Light', '-Medium', '-SemiBold', '-ExtraBold',
-        '-Thin', '-Black', '-Heavy',
-        '-Retina', '-Book',
-        'Regular', 'Bold', 'Italic',  # Without dash
+        "-Regular",
+        "-Bold",
+        "-Italic",
+        "-BoldItalic",
+        "-Light",
+        "-Medium",
+        "-SemiBold",
+        "-ExtraBold",
+        "-Thin",
+        "-Black",
+        "-Heavy",
+        "-Retina",
+        "-Book",
+        "Regular",
+        "Bold",
+        "Italic",  # Without dash
     ]
     for suffix in suffixes_to_remove:
         if name.endswith(suffix):
-            name = name[:-len(suffix)]
+            name = name[: -len(suffix)]
             break
 
     # Handle Nerd Font suffixes
-    nerd_font_suffix = ''
-    if '-NF' in name:
-        nerd_font_suffix = ' NF'
-        name = name.replace('-NF', '')
-    elif ' Nerd Font' in name:
+    nerd_font_suffix = ""
+    if "-NF" in name:
+        nerd_font_suffix = " NF"
+        name = name.replace("-NF", "")
+    elif " Nerd Font" in name:
         # Already friendly format
         return postscript_name
 
     # Split on dashes first
-    parts = name.split('-')
+    parts = name.split("-")
     friendly_parts = []
 
     for part in parts:
         # Insert spaces before uppercase letters (camelCase handling)
         # But be careful with acronyms like 'SF', 'LG', 'NF'
-        spaced = re.sub(r'([a-z])([A-Z])', r'\1 \2', part)
+        spaced = re.sub(r"([a-z])([A-Z])", r"\1 \2", part)
         # Handle cases like 'SFMono' -> 'SF Mono'
-        spaced = re.sub(r'([A-Z]+)([A-Z][a-z])', r'\1 \2', spaced)
+        spaced = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1 \2", spaced)
         friendly_parts.append(spaced)
 
-    result = ' '.join(friendly_parts)
+    result = " ".join(friendly_parts)
 
     # Re-add Nerd Font suffix
     if nerd_font_suffix:
         result += nerd_font_suffix
 
     # Clean up any double spaces
-    result = ' '.join(result.split())
+    result = " ".join(result.split())
 
     return result
 
 
-def friendly_to_postscript(friendly_name: str, weight: str = 'Regular') -> str:
+def friendly_to_postscript(friendly_name: str, weight: str = "Regular") -> str:
     """
     Convert a friendly font name to PostScript format.
 
@@ -98,10 +108,12 @@ def friendly_to_postscript(friendly_name: str, weight: str = 'Regular') -> str:
         return friendly_name
 
     # Remove spaces and join
-    postscript = friendly_name.replace(' ', '')
+    postscript = friendly_name.replace(" ", "")
 
     # Add weight suffix if not already present
-    if weight and not any(postscript.endswith(w) for w in ['Regular', 'Bold', 'Italic']):
+    if weight and not any(
+        postscript.endswith(w) for w in ["Regular", "Bold", "Italic"]
+    ):
         postscript = f"{postscript}-{weight}"
 
     return postscript
@@ -126,15 +138,23 @@ def is_postscript_name(font_name: str) -> bool:
         return False
 
     # If it has spaces, it's likely a friendly name
-    if ' ' in font_name:
+    if " " in font_name:
         return False
 
     # Check for common PostScript patterns
     postscript_patterns = [
-        r'-Regular$', r'-Bold$', r'-Italic$', r'-Light$', r'-Medium$',
-        r'-SemiBold$', r'-ExtraBold$', r'-Thin$', r'-Black$',
-        r'-Retina$', r'-Book$',
-        r'[a-z][A-Z]',  # CamelCase within word
+        r"-Regular$",
+        r"-Bold$",
+        r"-Italic$",
+        r"-Light$",
+        r"-Medium$",
+        r"-SemiBold$",
+        r"-ExtraBold$",
+        r"-Thin$",
+        r"-Black$",
+        r"-Retina$",
+        r"-Book$",
+        r"[a-z][A-Z]",  # CamelCase within word
     ]
 
     for pattern in postscript_patterns:
@@ -144,7 +164,7 @@ def is_postscript_name(font_name: str) -> bool:
     return False
 
 
-def extract_weight_from_name(font_name: str) -> tuple[str, Optional[str]]:
+def extract_weight_from_name(font_name: str) -> tuple[str, str | None]:
     """
     Extract weight/style suffix from a font name.
 
@@ -164,10 +184,23 @@ def extract_weight_from_name(font_name: str) -> tuple[str, Optional[str]]:
 
     # Common weight suffixes in order of specificity
     weights = [
-        'ExtraBold', 'SemiBold', 'UltraBold', 'DemiBold',
-        'ExtraLight', 'UltraLight',
-        'Bold', 'Light', 'Medium', 'Regular', 'Thin', 'Black', 'Heavy',
-        'Italic', 'Oblique', 'Retina', 'Book',
+        "ExtraBold",
+        "SemiBold",
+        "UltraBold",
+        "DemiBold",
+        "ExtraLight",
+        "UltraLight",
+        "Bold",
+        "Light",
+        "Medium",
+        "Regular",
+        "Thin",
+        "Black",
+        "Heavy",
+        "Italic",
+        "Oblique",
+        "Retina",
+        "Book",
     ]
 
     # Check PostScript format (with dash)
@@ -185,8 +218,8 @@ def extract_weight_from_name(font_name: str) -> tuple[str, Optional[str]]:
         if font_name.endswith(weight) and len(font_name) > len(weight):
             # Make sure we're not matching part of the font name
             base = font_name[: -len(weight)]
-            if base and (base[-1].islower() or base[-1] == '-'):
-                return (base.rstrip('-'), weight)
+            if base and (base[-1].islower() or base[-1] == "-"):
+                return (base.rstrip("-"), weight)
 
     return (font_name, None)
 

--- a/console_cowboy/validation.py
+++ b/console_cowboy/validation.py
@@ -6,7 +6,6 @@ when fonts are not found on the system.
 """
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple
 
 from .ctec.schema import CTEC, FontConfig
 from .utils.font_registry import find_similar_fonts, validate_font
@@ -16,9 +15,9 @@ from .utils.font_registry import find_similar_fonts, validate_font
 class ValidationResult:
     """Result of configuration validation."""
 
-    warnings: List[str] = field(default_factory=list)
-    errors: List[str] = field(default_factory=list)
-    suggestions: Dict[str, List[str]] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    suggestions: dict[str, list[str]] = field(default_factory=dict)
 
     @property
     def is_valid(self) -> bool:
@@ -38,7 +37,7 @@ class ValidationResult:
         """Add an error message."""
         self.errors.append(message)
 
-    def add_font_suggestion(self, font: str, alternatives: List[str]) -> None:
+    def add_font_suggestion(self, font: str, alternatives: list[str]) -> None:
         """Add font alternatives for a missing font."""
         self.suggestions[font] = alternatives
 
@@ -49,9 +48,7 @@ class ValidationResult:
         self.suggestions.update(other.suggestions)
 
 
-def _extract_fonts_from_config(
-    font: FontConfig, context: str
-) -> List[Tuple[str, str]]:
+def _extract_fonts_from_config(font: FontConfig, context: str) -> list[tuple[str, str]]:
     """Extract all font names from a FontConfig with their context."""
     fonts = []
 
@@ -87,7 +84,7 @@ def validate_fonts(ctec: CTEC) -> ValidationResult:
     """
     result = ValidationResult()
 
-    fonts_to_check: List[Tuple[str, str]] = []
+    fonts_to_check: list[tuple[str, str]] = []
 
     # Font config
     if ctec.font:
@@ -156,8 +153,7 @@ def validate_ctec(ctec: CTEC, check_fonts: bool = True) -> ValidationResult:
         if ctec.font.size is not None:
             if ctec.font.size < 4 or ctec.font.size > 72:
                 result.add_warning(
-                    f"Unusual font size: {ctec.font.size}pt. "
-                    "Expected range is 4-72pt"
+                    f"Unusual font size: {ctec.font.size}pt. Expected range is 4-72pt"
                 )
 
     return result

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,24 @@
+# lefthook.yml
+# Pre-commit hooks for Console Cowboy
+# See: https://lefthook.dev/
+
+pre-commit:
+  parallel: true
+  jobs:
+    - name: ruff-format
+      run: uv run ruff format --check {staged_files}
+      glob: "*.py"
+
+    - name: ruff-lint
+      run: uv run ruff check {staged_files}
+      glob: "*.py"
+
+    - name: cli-smoke-test
+      run: uv run console-cowboy --help > /dev/null && uv run console-cowboy list > /dev/null
+      glob: "*.py"
+
+    - name: uv-lock-check
+      run: uv lock --check
+      glob:
+        - "pyproject.toml"
+        - "uv.lock"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ classifiers = []
 dependencies = [
     "click",
     "pyyaml>=6.0",
+    "tomli>=2.0",
+    "tomli-w>=1.0",
 ]
 
 [build-system]
@@ -26,4 +28,40 @@ CI = "https://github.com/zetlen/console-cowboy/actions"
 console-cowboy = "console_cowboy.cli:cli"
 
 [project.optional-dependencies]
-test = ["pytest"]
+test = ["pytest", "pytest-cov"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 88
+src = ["console_cowboy", "tests"]
+
+[tool.ruff.lint]
+select = [
+    "E",      # pycodestyle errors
+    "W",      # pycodestyle warnings
+    "F",      # Pyflakes
+    "I",      # isort
+    "B",      # flake8-bugbear
+    "C4",     # flake8-comprehensions
+    "UP",     # pyupgrade
+]
+ignore = [
+    "E501",   # line too long (handled by formatter)
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["console_cowboy"]
+
+[tool.ruff.lint.per-file-ignores]
+"console_cowboy/cli.py" = ["B904"]  # Exception chaining not needed for CLI user errors
+"scripts/*" = ["E402"]  # Scripts need to modify sys.path before imports
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+[dependency-groups]
+dev = [
+    "lefthook>=2.0.15",
+    "ruff>=0.4",
+]

--- a/scripts/generate_schemas.py
+++ b/scripts/generate_schemas.py
@@ -22,7 +22,6 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
 from console_cowboy.ctec.serializers import (
-    CTECSerializer,
     CTEC_JSON_SCHEMA_BUNDLED,
     ITERM2_COLOR_SCHEME_SCHEMA,
 )

--- a/tests/test_console_cowboy.py
+++ b/tests/test_console_cowboy.py
@@ -10,7 +10,6 @@ from click.testing import CliRunner
 
 from console_cowboy.cli import cli
 
-
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
@@ -123,9 +122,7 @@ class TestExportCommand:
 
     def test_export_wezterm(self, runner):
         config_path = FIXTURES_DIR / "wezterm" / "wezterm.lua"
-        result = runner.invoke(
-            cli, ["export", "wezterm", "-i", str(config_path), "-q"]
-        )
+        result = runner.invoke(cli, ["export", "wezterm", "-i", str(config_path), "-q"])
 
         assert result.exit_code == 0
         parsed = yaml.safe_load(result.output)
@@ -140,9 +137,7 @@ class TestExportCommand:
         assert parsed["source_terminal"] == "iterm2"
 
     def test_export_nonexistent_file(self, runner):
-        result = runner.invoke(
-            cli, ["export", "ghostty", "-i", "/nonexistent/path"]
-        )
+        result = runner.invoke(cli, ["export", "ghostty", "-i", "/nonexistent/path"])
         assert result.exit_code != 0
         assert "Error" in result.output or "not found" in result.output.lower()
 
@@ -413,7 +408,9 @@ class TestRoundTrip:
             assert parsed["source_terminal"] == terminal
 
             # Import to same terminal
-            with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".yaml", delete=False
+            ) as f:
                 f.write(export_result.output)
                 ctec_path = f.name
 

--- a/tests/test_ctec_schema.py
+++ b/tests/test_ctec_schema.py
@@ -11,8 +11,8 @@ from console_cowboy.ctec.schema import (
     CursorConfig,
     CursorStyle,
     FontConfig,
-    FontWeight,
     FontStyle,
+    FontWeight,
     KeyBinding,
     ScrollConfig,
     TerminalSpecificSetting,
@@ -112,19 +112,23 @@ class TestColorScheme:
 
     def test_from_dict_hex_strings(self):
         """Test from_dict with hex strings (iTerm2-Color-Schemes format)."""
-        scheme = ColorScheme.from_dict({
-            "name": "Test",
-            "foreground": "#ffffff",
-        })
+        scheme = ColorScheme.from_dict(
+            {
+                "name": "Test",
+                "foreground": "#ffffff",
+            }
+        )
         assert scheme.name == "Test"
         assert scheme.foreground.r == 255
 
     def test_from_dict_rgb_dicts(self):
         """Test from_dict with RGB dicts (legacy format for backwards compatibility)."""
-        scheme = ColorScheme.from_dict({
-            "name": "Test",
-            "foreground": {"r": 255, "g": 255, "b": 255},
-        })
+        scheme = ColorScheme.from_dict(
+            {
+                "name": "Test",
+                "foreground": {"r": 255, "g": 255, "b": 255},
+            }
+        )
         assert scheme.name == "Test"
         assert scheme.foreground.r == 255
 
@@ -261,12 +265,14 @@ class TestFontConfig:
 
     def test_from_dict_with_new_fields(self):
         """Test deserialization with new fields."""
-        font = FontConfig.from_dict({
-            "family": "Fira Code",
-            "weight": "bold",
-            "style": "italic",
-            "fallback_fonts": ["Menlo", "Monaco"],
-        })
+        font = FontConfig.from_dict(
+            {
+                "family": "Fira Code",
+                "weight": "bold",
+                "style": "italic",
+                "fallback_fonts": ["Menlo", "Monaco"],
+            }
+        )
         assert font.family == "Fira Code"
         assert font.weight == FontWeight.BOLD
         assert font.style == FontStyle.ITALIC
@@ -351,10 +357,9 @@ class TestBehaviorConfig:
         assert d["bell_mode"] == "none"
 
     def test_from_dict(self):
-        behavior = BehaviorConfig.from_dict({
-            "shell": "/bin/zsh",
-            "bell_mode": "audible"
-        })
+        behavior = BehaviorConfig.from_dict(
+            {"shell": "/bin/zsh", "bell_mode": "audible"}
+        )
         assert behavior.shell == "/bin/zsh"
         assert behavior.bell_mode == BellMode.AUDIBLE
 
@@ -411,11 +416,13 @@ class TestTerminalSpecificSetting:
         assert d["value"] == "yes"
 
     def test_from_dict(self):
-        setting = TerminalSpecificSetting.from_dict({
-            "terminal": "ghostty",
-            "key": "gtk-single-instance",
-            "value": True,
-        })
+        setting = TerminalSpecificSetting.from_dict(
+            {
+                "terminal": "ghostty",
+                "key": "gtk-single-instance",
+                "value": True,
+            }
+        )
         assert setting.terminal == "ghostty"
         assert setting.key == "gtk-single-instance"
         assert setting.value is True
@@ -477,11 +484,13 @@ class TestCTEC:
         assert d["font"]["family"] == "Fira Code"
 
     def test_from_dict(self):
-        ctec = CTEC.from_dict({
-            "version": "1.0",
-            "source_terminal": "alacritty",
-            "font": {"family": "Monaco", "size": 14.0},
-        })
+        ctec = CTEC.from_dict(
+            {
+                "version": "1.0",
+                "source_terminal": "alacritty",
+                "font": {"family": "Monaco", "size": 14.0},
+            }
+        )
         assert ctec.source_terminal == "alacritty"
         assert ctec.font.family == "Monaco"
         assert ctec.font.size == 14.0

--- a/tests/test_font_fixes.py
+++ b/tests/test_font_fixes.py
@@ -22,9 +22,7 @@ class TestKittyLigaturesFix:
 
     def test_ligatures_enabled_roundtrip(self):
         """Test ligatures=True exports as disable_ligatures=never and imports back correctly."""
-        ctec = CTEC(
-            font=FontConfig(family="JetBrains Mono", ligatures=True)
-        )
+        ctec = CTEC(font=FontConfig(family="JetBrains Mono", ligatures=True))
         exported = KittyAdapter.export(ctec)
 
         # Should export as "never" (meaning ligatures are NOT disabled)
@@ -36,9 +34,7 @@ class TestKittyLigaturesFix:
 
     def test_ligatures_disabled_roundtrip(self):
         """Test ligatures=False exports as disable_ligatures=always and imports back correctly."""
-        ctec = CTEC(
-            font=FontConfig(family="JetBrains Mono", ligatures=False)
-        )
+        ctec = CTEC(font=FontConfig(family="JetBrains Mono", ligatures=False))
         exported = KittyAdapter.export(ctec)
 
         # Should export as "always" (meaning ligatures ARE disabled)
@@ -92,9 +88,7 @@ adjust-cell-width = 5%
 
     def test_cell_width_roundtrip(self):
         """Test cell_width exports and imports correctly."""
-        ctec = CTEC(
-            font=FontConfig(family="JetBrains Mono", cell_width=1.10)
-        )
+        ctec = CTEC(font=FontConfig(family="JetBrains Mono", cell_width=1.10))
         exported = GhosttyAdapter.export(ctec)
 
         # Should export as integer (10 for 10%)
@@ -122,7 +116,7 @@ class TestWeztermWeightWithFallbacks:
         # Should include both weight and fallbacks in font_with_fallback
         assert 'family = "JetBrains Mono"' in exported
         assert 'weight = "Bold"' in exported
-        assert 'Symbols Nerd Font' in exported
+        assert "Symbols Nerd Font" in exported
         assert "font_with_fallback" in exported
 
     def test_parse_weight_with_fallbacks(self):
@@ -211,7 +205,9 @@ symbol_map U+F000-U+F8FF Font Awesome
         ctec = KittyAdapter.parse("test", content=content)
         assert ctec.font.symbol_map is not None
         assert len(ctec.font.symbol_map) == 2
-        assert ctec.font.symbol_map["U+E0A0-U+E0A3,U+E0B0-U+E0B3"] == "Symbols Nerd Font"
+        assert (
+            ctec.font.symbol_map["U+E0A0-U+E0A3,U+E0B0-U+E0B3"] == "Symbols Nerd Font"
+        )
         assert ctec.font.symbol_map["U+F000-U+F8FF"] == "Font Awesome"
 
     def test_export_symbol_map(self):
@@ -260,6 +256,7 @@ class TestITerm2PowerlineGlyphs:
 
         # Parse the plist output
         import plistlib
+
         data = plistlib.loads(exported.encode())
         profile = data["New Bookmarks"][0]
         assert profile["Draw Powerline Glyphs"] is True

--- a/tests/test_font_registry.py
+++ b/tests/test_font_registry.py
@@ -1,12 +1,10 @@
 """Tests for font registry and validation utilities."""
 
-import pytest
-
 from console_cowboy.utils.font_registry import (
     FontInfo,
     FontRegistry,
-    font_exists,
     find_similar_fonts,
+    font_exists,
     validate_font,
 )
 
@@ -60,7 +58,9 @@ class TestFontRegistry:
         registry = FontRegistry()
         # Spaces and dashes should be removed, lowercased
         assert registry._normalize_name("JetBrains Mono") == "jetbrainsmono"
-        assert registry._normalize_name("JetBrainsMono-Regular") == "jetbrainsmonoregular"
+        assert (
+            registry._normalize_name("JetBrainsMono-Regular") == "jetbrainsmonoregular"
+        )
 
     def test_similarity_score(self):
         """Test similarity scoring."""

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -1,13 +1,11 @@
 """Tests for font name conversion utilities."""
 
-import pytest
-
 from console_cowboy.utils.fonts import (
-    is_postscript_name,
-    postscript_to_friendly,
-    friendly_to_postscript,
     extract_weight_from_name,
+    friendly_to_postscript,
+    is_postscript_name,
     normalize_font_family,
+    postscript_to_friendly,
 )
 
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -16,11 +16,11 @@ from console_cowboy.ctec.schema import (
     FontConfig,
 )
 from console_cowboy.ctec.serializers import (
-    CTECSerializer,
-    OutputFormat,
     CTEC_JSON_SCHEMA,
     CTEC_JSON_SCHEMA_BUNDLED,
     ITERM2_COLOR_SCHEME_SCHEMA,
+    CTECSerializer,
+    OutputFormat,
 )
 
 
@@ -298,4 +298,7 @@ class TestJSONSchema:
     def test_unbundled_schema_has_ref(self):
         """Test that unbundled schema uses $ref for color_scheme."""
         assert "$ref" in CTEC_JSON_SCHEMA["properties"]["color_scheme"]
-        assert CTEC_JSON_SCHEMA["properties"]["color_scheme"]["$ref"] == "iterm2-color-scheme.schema.json"
+        assert (
+            CTEC_JSON_SCHEMA["properties"]["color_scheme"]["$ref"]
+            == "iterm2-color-scheme.schema.json"
+        )

--- a/tests/test_terminals.py
+++ b/tests/test_terminals.py
@@ -2,8 +2,6 @@
 
 from pathlib import Path
 
-import pytest
-
 from console_cowboy.ctec.schema import (
     CTEC,
     BellMode,
@@ -22,7 +20,6 @@ from console_cowboy.terminals import (
     TerminalRegistry,
     WeztermAdapter,
 )
-
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,7 +1,5 @@
 """Tests for CTEC validation utilities."""
 
-import pytest
-
 from console_cowboy.ctec.schema import (
     CTEC,
     FontConfig,
@@ -9,9 +7,9 @@ from console_cowboy.ctec.schema import (
 )
 from console_cowboy.validation import (
     ValidationResult,
-    validate_fonts,
-    validate_ctec,
     format_validation_result,
+    validate_ctec,
+    validate_fonts,
 )
 
 
@@ -76,9 +74,7 @@ class TestValidateFonts:
 
     def test_missing_font_warning(self):
         """Test that missing fonts generate warnings."""
-        ctec = CTEC(
-            font=FontConfig(family="NonexistentFont12345")
-        )
+        ctec = CTEC(font=FontConfig(family="NonexistentFont12345"))
         result = validate_fonts(ctec)
         # Should have a warning about the missing font
         assert result.has_warnings is True
@@ -96,12 +92,13 @@ class TestValidateCTEC:
 
     def test_scroll_config_conflicting_flags(self):
         """Test warning for conflicting scroll config."""
-        ctec = CTEC(
-            scroll=ScrollConfig(disabled=True, unlimited=True)
-        )
+        ctec = CTEC(scroll=ScrollConfig(disabled=True, unlimited=True))
         result = validate_ctec(ctec, check_fonts=False)
         assert result.has_warnings is True
-        assert any("disabled" in w.lower() and "unlimited" in w.lower() for w in result.warnings)
+        assert any(
+            "disabled" in w.lower() and "unlimited" in w.lower()
+            for w in result.warnings
+        )
 
     def test_unusual_font_size_warning(self):
         """Test warning for unusual font size."""

--- a/uv.lock
+++ b/uv.lock
@@ -37,17 +37,135 @@ dependencies = [
 [package.optional-dependencies]
 test = [
     { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "lefthook" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "click" },
     { name = "pytest", marker = "extra == 'test'" },
+    { name = "pytest-cov", marker = "extra == 'test'" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "tomli", specifier = ">=2.0" },
     { name = "tomli-w", specifier = ">=1.0" },
 ]
 provides-extras = ["test"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "lefthook", specifier = ">=2.0.15" },
+    { name = "ruff", specifier = ">=0.4" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/f9/e92df5e07f3fc8d4c7f9a0f146ef75446bf870351cd37b788cf5897f8079/coverage-7.13.1.tar.gz", hash = "sha256:b7593fe7eb5feaa3fbb461ac79aac9f9fc0387a5ca8080b0c6fe2ca27b091afd", size = 825862, upload-time = "2025-12-28T15:42:56.969Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/9a/3742e58fd04b233df95c012ee9f3dfe04708a5e1d32613bd2d47d4e1be0d/coverage-7.13.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e1fa280b3ad78eea5be86f94f461c04943d942697e0dac889fa18fff8f5f9147", size = 218633, upload-time = "2025-12-28T15:40:10.165Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/45/7e6bdc94d89cd7c8017ce735cf50478ddfe765d4fbf0c24d71d30ea33d7a/coverage-7.13.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c3d8c679607220979434f494b139dfb00131ebf70bb406553d69c1ff01a5c33d", size = 219147, upload-time = "2025-12-28T15:40:12.069Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/38/0d6a258625fd7f10773fe94097dc16937a5f0e3e0cdf3adef67d3ac6baef/coverage-7.13.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:339dc63b3eba969067b00f41f15ad161bf2946613156fb131266d8debc8e44d0", size = 245894, upload-time = "2025-12-28T15:40:13.556Z" },
+    { url = "https://files.pythonhosted.org/packages/27/58/409d15ea487986994cbd4d06376e9860e9b157cfbfd402b1236770ab8dd2/coverage-7.13.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:db622b999ffe49cb891f2fff3b340cdc2f9797d01a0a202a0973ba2562501d90", size = 247721, upload-time = "2025-12-28T15:40:15.37Z" },
+    { url = "https://files.pythonhosted.org/packages/da/bf/6e8056a83fd7a96c93341f1ffe10df636dd89f26d5e7b9ca511ce3bcf0df/coverage-7.13.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1443ba9acbb593fa7c1c29e011d7c9761545fe35e7652e85ce7f51a16f7e08d", size = 249585, upload-time = "2025-12-28T15:40:17.226Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/15/e1daff723f9f5959acb63cbe35b11203a9df77ee4b95b45fffd38b318390/coverage-7.13.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c832ec92c4499ac463186af72f9ed4d8daec15499b16f0a879b0d1c8e5cf4a3b", size = 246597, upload-time = "2025-12-28T15:40:19.028Z" },
+    { url = "https://files.pythonhosted.org/packages/74/a6/1efd31c5433743a6ddbc9d37ac30c196bb07c7eab3d74fbb99b924c93174/coverage-7.13.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:562ec27dfa3f311e0db1ba243ec6e5f6ab96b1edfcfc6cf86f28038bc4961ce6", size = 247626, upload-time = "2025-12-28T15:40:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/9f/1609267dd3e749f57fdd66ca6752567d1c13b58a20a809dc409b263d0b5f/coverage-7.13.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:4de84e71173d4dada2897e5a0e1b7877e5eefbfe0d6a44edee6ce31d9b8ec09e", size = 245629, upload-time = "2025-12-28T15:40:22.397Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/f6/6815a220d5ec2466383d7cc36131b9fa6ecbe95c50ec52a631ba733f306a/coverage-7.13.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:a5a68357f686f8c4d527a2dc04f52e669c2fc1cbde38f6f7eb6a0e58cbd17cae", size = 245901, upload-time = "2025-12-28T15:40:23.836Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/58/40576554cd12e0872faf6d2c0eb3bc85f71d78427946ddd19ad65201e2c0/coverage-7.13.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:77cc258aeb29a3417062758975521eae60af6f79e930d6993555eeac6a8eac29", size = 246505, upload-time = "2025-12-28T15:40:25.421Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/77/9233a90253fba576b0eee81707b5781d0e21d97478e5377b226c5b096c0f/coverage-7.13.1-cp310-cp310-win32.whl", hash = "sha256:bb4f8c3c9a9f34423dba193f241f617b08ffc63e27f67159f60ae6baf2dcfe0f", size = 221257, upload-time = "2025-12-28T15:40:27.217Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/43/e842ff30c1a0a623ec80db89befb84a3a7aad7bfe44a6ea77d5a3e61fedd/coverage-7.13.1-cp310-cp310-win_amd64.whl", hash = "sha256:c8e2706ceb622bc63bac98ebb10ef5da80ed70fbd8a7999a5076de3afaef0fb1", size = 222191, upload-time = "2025-12-28T15:40:28.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/9b/77baf488516e9ced25fc215a6f75d803493fc3f6a1a1227ac35697910c2a/coverage-7.13.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1a55d509a1dc5a5b708b5dad3b5334e07a16ad4c2185e27b40e4dba796ab7f88", size = 218755, upload-time = "2025-12-28T15:40:30.812Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/cd/7ab01154e6eb79ee2fab76bf4d89e94c6648116557307ee4ebbb85e5c1bf/coverage-7.13.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4d010d080c4888371033baab27e47c9df7d6fb28d0b7b7adf85a4a49be9298b3", size = 219257, upload-time = "2025-12-28T15:40:32.333Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d5/b11ef7863ffbbdb509da0023fad1e9eda1c0eaea61a6d2ea5b17d4ac706e/coverage-7.13.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d938b4a840fb1523b9dfbbb454f652967f18e197569c32266d4d13f37244c3d9", size = 249657, upload-time = "2025-12-28T15:40:34.1Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7c/347280982982383621d29b8c544cf497ae07ac41e44b1ca4903024131f55/coverage-7.13.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bf100a3288f9bb7f919b87eb84f87101e197535b9bd0e2c2b5b3179633324fee", size = 251581, upload-time = "2025-12-28T15:40:36.131Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f6/ebcfed11036ade4c0d75fa4453a6282bdd225bc073862766eec184a4c643/coverage-7.13.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef6688db9bf91ba111ae734ba6ef1a063304a881749726e0d3575f5c10a9facf", size = 253691, upload-time = "2025-12-28T15:40:37.626Z" },
+    { url = "https://files.pythonhosted.org/packages/02/92/af8f5582787f5d1a8b130b2dcba785fa5e9a7a8e121a0bb2220a6fdbdb8a/coverage-7.13.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0b609fc9cdbd1f02e51f67f51e5aee60a841ef58a68d00d5ee2c0faf357481a3", size = 249799, upload-time = "2025-12-28T15:40:39.47Z" },
+    { url = "https://files.pythonhosted.org/packages/24/aa/0e39a2a3b16eebf7f193863323edbff38b6daba711abaaf807d4290cf61a/coverage-7.13.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c43257717611ff5e9a1d79dce8e47566235ebda63328718d9b65dd640bc832ef", size = 251389, upload-time = "2025-12-28T15:40:40.954Z" },
+    { url = "https://files.pythonhosted.org/packages/73/46/7f0c13111154dc5b978900c0ccee2e2ca239b910890e674a77f1363d483e/coverage-7.13.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e09fbecc007f7b6afdfb3b07ce5bd9f8494b6856dd4f577d26c66c391b829851", size = 249450, upload-time = "2025-12-28T15:40:42.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ca/e80da6769e8b669ec3695598c58eef7ad98b0e26e66333996aee6316db23/coverage-7.13.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a03a4f3a19a189919c7055098790285cc5c5b0b3976f8d227aea39dbf9f8bfdb", size = 249170, upload-time = "2025-12-28T15:40:44.279Z" },
+    { url = "https://files.pythonhosted.org/packages/af/18/9e29baabdec1a8644157f572541079b4658199cfd372a578f84228e860de/coverage-7.13.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3820778ea1387c2b6a818caec01c63adc5b3750211af6447e8dcfb9b6f08dbba", size = 250081, upload-time = "2025-12-28T15:40:45.748Z" },
+    { url = "https://files.pythonhosted.org/packages/00/f8/c3021625a71c3b2f516464d322e41636aea381018319050a8114105872ee/coverage-7.13.1-cp311-cp311-win32.whl", hash = "sha256:ff10896fa55167371960c5908150b434b71c876dfab97b69478f22c8b445ea19", size = 221281, upload-time = "2025-12-28T15:40:47.232Z" },
+    { url = "https://files.pythonhosted.org/packages/27/56/c216625f453df6e0559ed666d246fcbaaa93f3aa99eaa5080cea1229aa3d/coverage-7.13.1-cp311-cp311-win_amd64.whl", hash = "sha256:a998cc0aeeea4c6d5622a3754da5a493055d2d95186bad877b0a34ea6e6dbe0a", size = 222215, upload-time = "2025-12-28T15:40:49.19Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/9a/be342e76f6e531cae6406dc46af0d350586f24d9b67fdfa6daee02df71af/coverage-7.13.1-cp311-cp311-win_arm64.whl", hash = "sha256:fea07c1a39a22614acb762e3fbbb4011f65eedafcb2948feeef641ac78b4ee5c", size = 220886, upload-time = "2025-12-28T15:40:51.067Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8a/87af46cccdfa78f53db747b09f5f9a21d5fc38d796834adac09b30a8ce74/coverage-7.13.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6f34591000f06e62085b1865c9bc5f7858df748834662a51edadfd2c3bfe0dd3", size = 218927, upload-time = "2025-12-28T15:40:52.814Z" },
+    { url = "https://files.pythonhosted.org/packages/82/a8/6e22fdc67242a4a5a153f9438d05944553121c8f4ba70cb072af4c41362e/coverage-7.13.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b67e47c5595b9224599016e333f5ec25392597a89d5744658f837d204e16c63e", size = 219288, upload-time = "2025-12-28T15:40:54.262Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/0a/853a76e03b0f7c4375e2ca025df45c918beb367f3e20a0a8e91967f6e96c/coverage-7.13.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3e7b8bd70c48ffb28461ebe092c2345536fb18bbbf19d287c8913699735f505c", size = 250786, upload-time = "2025-12-28T15:40:56.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b4/694159c15c52b9f7ec7adf49d50e5f8ee71d3e9ef38adb4445d13dd56c20/coverage-7.13.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c223d078112e90dc0e5c4e35b98b9584164bea9fbbd221c0b21c5241f6d51b62", size = 253543, upload-time = "2025-12-28T15:40:57.585Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b2/7f1f0437a5c855f87e17cf5d0dc35920b6440ff2b58b1ba9788c059c26c8/coverage-7.13.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:794f7c05af0763b1bbd1b9e6eff0e52ad068be3b12cd96c87de037b01390c968", size = 254635, upload-time = "2025-12-28T15:40:59.443Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d1/73c3fdb8d7d3bddd9473c9c6a2e0682f09fc3dfbcb9c3f36412a7368bcab/coverage-7.13.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0642eae483cc8c2902e4af7298bf886d605e80f26382124cddc3967c2a3df09e", size = 251202, upload-time = "2025-12-28T15:41:01.328Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3c/f0edf75dcc152f145d5598329e864bbbe04ab78660fe3e8e395f9fff010f/coverage-7.13.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9f5e772ed5fef25b3de9f2008fe67b92d46831bd2bc5bdc5dd6bfd06b83b316f", size = 252566, upload-time = "2025-12-28T15:41:03.319Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b3/e64206d3c5f7dcbceafd14941345a754d3dbc78a823a6ed526e23b9cdaab/coverage-7.13.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:45980ea19277dc0a579e432aef6a504fe098ef3a9032ead15e446eb0f1191aee", size = 250711, upload-time = "2025-12-28T15:41:06.411Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ad/28a3eb970a8ef5b479ee7f0c484a19c34e277479a5b70269dc652b730733/coverage-7.13.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e4f18eca6028ffa62adbd185a8f1e1dd242f2e68164dba5c2b74a5204850b4cf", size = 250278, upload-time = "2025-12-28T15:41:08.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/e3/c8f0f1a93133e3e1291ca76cbb63565bd4b5c5df63b141f539d747fff348/coverage-7.13.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8dca5590fec7a89ed6826fce625595279e586ead52e9e958d3237821fbc750c", size = 252154, upload-time = "2025-12-28T15:41:09.969Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/bf/9939c5d6859c380e405b19e736321f1c7d402728792f4c752ad1adcce005/coverage-7.13.1-cp312-cp312-win32.whl", hash = "sha256:ff86d4e85188bba72cfb876df3e11fa243439882c55957184af44a35bd5880b7", size = 221487, upload-time = "2025-12-28T15:41:11.468Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/dc/7282856a407c621c2aad74021680a01b23010bb8ebf427cf5eacda2e876f/coverage-7.13.1-cp312-cp312-win_amd64.whl", hash = "sha256:16cc1da46c04fb0fb128b4dc430b78fa2aba8a6c0c9f8eb391fd5103409a6ac6", size = 222299, upload-time = "2025-12-28T15:41:13.386Z" },
+    { url = "https://files.pythonhosted.org/packages/10/79/176a11203412c350b3e9578620013af35bcdb79b651eb976f4a4b32044fa/coverage-7.13.1-cp312-cp312-win_arm64.whl", hash = "sha256:8d9bc218650022a768f3775dd7fdac1886437325d8d295d923ebcfef4892ad5c", size = 220941, upload-time = "2025-12-28T15:41:14.975Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/a4/e98e689347a1ff1a7f67932ab535cef82eb5e78f32a9e4132e114bbb3a0a/coverage-7.13.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:cb237bfd0ef4d5eb6a19e29f9e528ac67ac3be932ea6b44fb6cc09b9f3ecff78", size = 218951, upload-time = "2025-12-28T15:41:16.653Z" },
+    { url = "https://files.pythonhosted.org/packages/32/33/7cbfe2bdc6e2f03d6b240d23dc45fdaf3fd270aaf2d640be77b7f16989ab/coverage-7.13.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1dcb645d7e34dcbcc96cd7c132b1fc55c39263ca62eb961c064eb3928997363b", size = 219325, upload-time = "2025-12-28T15:41:18.609Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f6/efdabdb4929487baeb7cb2a9f7dac457d9356f6ad1b255be283d58b16316/coverage-7.13.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3d42df8201e00384736f0df9be2ced39324c3907607d17d50d50116c989d84cd", size = 250309, upload-time = "2025-12-28T15:41:20.629Z" },
+    { url = "https://files.pythonhosted.org/packages/12/da/91a52516e9d5aea87d32d1523f9cdcf7a35a3b298e6be05d6509ba3cfab2/coverage-7.13.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fa3edde1aa8807de1d05934982416cb3ec46d1d4d91e280bcce7cca01c507992", size = 252907, upload-time = "2025-12-28T15:41:22.257Z" },
+    { url = "https://files.pythonhosted.org/packages/75/38/f1ea837e3dc1231e086db1638947e00d264e7e8c41aa8ecacf6e1e0c05f4/coverage-7.13.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9edd0e01a343766add6817bc448408858ba6b489039eaaa2018474e4001651a4", size = 254148, upload-time = "2025-12-28T15:41:23.87Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/43/f4f16b881aaa34954ba446318dea6b9ed5405dd725dd8daac2358eda869a/coverage-7.13.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:985b7836931d033570b94c94713c6dba5f9d3ff26045f72c3e5dbc5fe3361e5a", size = 250515, upload-time = "2025-12-28T15:41:25.437Z" },
+    { url = "https://files.pythonhosted.org/packages/84/34/8cba7f00078bd468ea914134e0144263194ce849ec3baad187ffb6203d1c/coverage-7.13.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ffed1e4980889765c84a5d1a566159e363b71d6b6fbaf0bebc9d3c30bc016766", size = 252292, upload-time = "2025-12-28T15:41:28.459Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a4/cffac66c7652d84ee4ac52d3ccb94c015687d3b513f9db04bfcac2ac800d/coverage-7.13.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8842af7f175078456b8b17f1b73a0d16a65dcbdc653ecefeb00a56b3c8c298c4", size = 250242, upload-time = "2025-12-28T15:41:30.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/78/9a64d462263dde416f3c0067efade7b52b52796f489b1037a95b0dc389c9/coverage-7.13.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ccd7a6fca48ca9c131d9b0a2972a581e28b13416fc313fb98b6d24a03ce9a398", size = 250068, upload-time = "2025-12-28T15:41:32.007Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c8/a8994f5fece06db7c4a97c8fc1973684e178599b42e66280dded0524ef00/coverage-7.13.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0403f647055de2609be776965108447deb8e384fe4a553c119e3ff6bfbab4784", size = 251846, upload-time = "2025-12-28T15:41:33.946Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f7/91fa73c4b80305c86598a2d4e54ba22df6bf7d0d97500944af7ef155d9f7/coverage-7.13.1-cp313-cp313-win32.whl", hash = "sha256:549d195116a1ba1e1ae2f5ca143f9777800f6636eab917d4f02b5310d6d73461", size = 221512, upload-time = "2025-12-28T15:41:35.519Z" },
+    { url = "https://files.pythonhosted.org/packages/45/0b/0768b4231d5a044da8f75e097a8714ae1041246bb765d6b5563bab456735/coverage-7.13.1-cp313-cp313-win_amd64.whl", hash = "sha256:5899d28b5276f536fcf840b18b61a9fce23cc3aec1d114c44c07fe94ebeaa500", size = 222321, upload-time = "2025-12-28T15:41:37.371Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b8/bdcb7253b7e85157282450262008f1366aa04663f3e3e4c30436f596c3e2/coverage-7.13.1-cp313-cp313-win_arm64.whl", hash = "sha256:868a2fae76dfb06e87291bcbd4dcbcc778a8500510b618d50496e520bd94d9b9", size = 220949, upload-time = "2025-12-28T15:41:39.553Z" },
+    { url = "https://files.pythonhosted.org/packages/70/52/f2be52cc445ff75ea8397948c96c1b4ee14f7f9086ea62fc929c5ae7b717/coverage-7.13.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:67170979de0dacac3f3097d02b0ad188d8edcea44ccc44aaa0550af49150c7dc", size = 219643, upload-time = "2025-12-28T15:41:41.567Z" },
+    { url = "https://files.pythonhosted.org/packages/47/79/c85e378eaa239e2edec0c5523f71542c7793fe3340954eafb0bc3904d32d/coverage-7.13.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f80e2bb21bfab56ed7405c2d79d34b5dc0bc96c2c1d2a067b643a09fb756c43a", size = 219997, upload-time = "2025-12-28T15:41:43.418Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/9b/b1ade8bfb653c0bbce2d6d6e90cc6c254cbb99b7248531cc76253cb4da6d/coverage-7.13.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f83351e0f7dcdb14d7326c3d8d8c4e915fa685cbfdc6281f9470d97a04e9dfe4", size = 261296, upload-time = "2025-12-28T15:41:45.207Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/af/ebf91e3e1a2473d523e87e87fd8581e0aa08741b96265730e2d79ce78d8d/coverage-7.13.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bb3f6562e89bad0110afbe64e485aac2462efdce6232cdec7862a095dc3412f6", size = 263363, upload-time = "2025-12-28T15:41:47.163Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8b/fb2423526d446596624ac7fde12ea4262e66f86f5120114c3cfd0bb2befa/coverage-7.13.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77545b5dcda13b70f872c3b5974ac64c21d05e65b1590b441c8560115dc3a0d1", size = 265783, upload-time = "2025-12-28T15:41:49.03Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/26/ef2adb1e22674913b89f0fe7490ecadcef4a71fa96f5ced90c60ec358789/coverage-7.13.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4d240d260a1aed814790bbe1f10a5ff31ce6c21bc78f0da4a1e8268d6c80dbd", size = 260508, upload-time = "2025-12-28T15:41:51.035Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/7d/f0f59b3404caf662e7b5346247883887687c074ce67ba453ea08c612b1d5/coverage-7.13.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d2287ac9360dec3837bfdad969963a5d073a09a85d898bd86bea82aa8876ef3c", size = 263357, upload-time = "2025-12-28T15:41:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b1/29896492b0b1a047604d35d6fa804f12818fa30cdad660763a5f3159e158/coverage-7.13.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:0d2c11f3ea4db66b5cbded23b20185c35066892c67d80ec4be4bab257b9ad1e0", size = 260978, upload-time = "2025-12-28T15:41:54.589Z" },
+    { url = "https://files.pythonhosted.org/packages/48/f2/971de1238a62e6f0a4128d37adadc8bb882ee96afbe03ff1570291754629/coverage-7.13.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:3fc6a169517ca0d7ca6846c3c5392ef2b9e38896f61d615cb75b9e7134d4ee1e", size = 259877, upload-time = "2025-12-28T15:41:56.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fc/0474efcbb590ff8628830e9aaec5f1831594874360e3251f1fdec31d07a3/coverage-7.13.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d10a2ed46386e850bb3de503a54f9fe8192e5917fcbb143bfef653a9355e9a53", size = 262069, upload-time = "2025-12-28T15:41:58.093Z" },
+    { url = "https://files.pythonhosted.org/packages/88/4f/3c159b7953db37a7b44c0eab8a95c37d1aa4257c47b4602c04022d5cb975/coverage-7.13.1-cp313-cp313t-win32.whl", hash = "sha256:75a6f4aa904301dab8022397a22c0039edc1f51e90b83dbd4464b8a38dc87842", size = 222184, upload-time = "2025-12-28T15:41:59.763Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a5/6b57d28f81417f9335774f20679d9d13b9a8fb90cd6160957aa3b54a2379/coverage-7.13.1-cp313-cp313t-win_amd64.whl", hash = "sha256:309ef5706e95e62578cda256b97f5e097916a2c26247c287bbe74794e7150df2", size = 223250, upload-time = "2025-12-28T15:42:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/81/7c/160796f3b035acfbb58be80e02e484548595aa67e16a6345e7910ace0a38/coverage-7.13.1-cp313-cp313t-win_arm64.whl", hash = "sha256:92f980729e79b5d16d221038dbf2e8f9a9136afa072f9d5d6ed4cb984b126a09", size = 221521, upload-time = "2025-12-28T15:42:03.275Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/8e/ba0e597560c6563fc0adb902fda6526df5d4aa73bb10adf0574d03bd2206/coverage-7.13.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:97ab3647280d458a1f9adb85244e81587505a43c0c7cff851f5116cd2814b894", size = 218996, upload-time = "2025-12-28T15:42:04.978Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8e/764c6e116f4221dc7aa26c4061181ff92edb9c799adae6433d18eeba7a14/coverage-7.13.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8f572d989142e0908e6acf57ad1b9b86989ff057c006d13b76c146ec6a20216a", size = 219326, upload-time = "2025-12-28T15:42:06.691Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a6/6130dc6d8da28cdcbb0f2bf8865aeca9b157622f7c0031e48c6cf9a0e591/coverage-7.13.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d72140ccf8a147e94274024ff6fd8fb7811354cf7ef88b1f0a988ebaa5bc774f", size = 250374, upload-time = "2025-12-28T15:42:08.786Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2b/783ded568f7cd6b677762f780ad338bf4b4750205860c17c25f7c708995e/coverage-7.13.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d3c9f051b028810f5a87c88e5d6e9af3c0ff32ef62763bf15d29f740453ca909", size = 252882, upload-time = "2025-12-28T15:42:10.515Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b2/9808766d082e6a4d59eb0cc881a57fc1600eb2c5882813eefff8254f71b5/coverage-7.13.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f398ba4df52d30b1763f62eed9de5620dcde96e6f491f4c62686736b155aa6e4", size = 254218, upload-time = "2025-12-28T15:42:12.208Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ea/52a985bb447c871cb4d2e376e401116520991b597c85afdde1ea9ef54f2c/coverage-7.13.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:132718176cc723026d201e347f800cd1a9e4b62ccd3f82476950834dad501c75", size = 250391, upload-time = "2025-12-28T15:42:14.21Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/1d/125b36cc12310718873cfc8209ecfbc1008f14f4f5fa0662aa608e579353/coverage-7.13.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e549d642426e3579b3f4b92d0431543b012dcb6e825c91619d4e93b7363c3f9", size = 252239, upload-time = "2025-12-28T15:42:16.292Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/16/10c1c164950cade470107f9f14bbac8485f8fb8515f515fca53d337e4a7f/coverage-7.13.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:90480b2134999301eea795b3a9dbf606c6fbab1b489150c501da84a959442465", size = 250196, upload-time = "2025-12-28T15:42:18.54Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c6/cd860fac08780c6fd659732f6ced1b40b79c35977c1356344e44d72ba6c4/coverage-7.13.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e825dbb7f84dfa24663dd75835e7257f8882629fc11f03ecf77d84a75134b864", size = 250008, upload-time = "2025-12-28T15:42:20.365Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/a8c58d3d38f82a5711e1e0a67268362af48e1a03df27c03072ac30feefcf/coverage-7.13.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:623dcc6d7a7ba450bbdbeedbaa0c42b329bdae16491af2282f12a7e809be7eb9", size = 251671, upload-time = "2025-12-28T15:42:22.114Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/bc/fd4c1da651d037a1e3d53e8cb3f8182f4b53271ffa9a95a2e211bacc0349/coverage-7.13.1-cp314-cp314-win32.whl", hash = "sha256:6e73ebb44dca5f708dc871fe0b90cf4cff1a13f9956f747cc87b535a840386f5", size = 221777, upload-time = "2025-12-28T15:42:23.919Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/50/71acabdc8948464c17e90b5ffd92358579bd0910732c2a1c9537d7536aa6/coverage-7.13.1-cp314-cp314-win_amd64.whl", hash = "sha256:be753b225d159feb397bd0bf91ae86f689bad0da09d3b301478cd39b878ab31a", size = 222592, upload-time = "2025-12-28T15:42:25.619Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/c8/a6fb943081bb0cc926499c7907731a6dc9efc2cbdc76d738c0ab752f1a32/coverage-7.13.1-cp314-cp314-win_arm64.whl", hash = "sha256:228b90f613b25ba0019361e4ab81520b343b622fc657daf7e501c4ed6a2366c0", size = 221169, upload-time = "2025-12-28T15:42:27.629Z" },
+    { url = "https://files.pythonhosted.org/packages/16/61/d5b7a0a0e0e40d62e59bc8c7aa1afbd86280d82728ba97f0673b746b78e2/coverage-7.13.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:60cfb538fe9ef86e5b2ab0ca8fc8d62524777f6c611dcaf76dc16fbe9b8e698a", size = 219730, upload-time = "2025-12-28T15:42:29.306Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2c/8881326445fd071bb49514d1ce97d18a46a980712b51fee84f9ab42845b4/coverage-7.13.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:57dfc8048c72ba48a8c45e188d811e5efd7e49b387effc8fb17e97936dde5bf6", size = 220001, upload-time = "2025-12-28T15:42:31.319Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d7/50de63af51dfa3a7f91cc37ad8fcc1e244b734232fbc8b9ab0f3c834a5cd/coverage-7.13.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3f2f725aa3e909b3c5fdb8192490bdd8e1495e85906af74fe6e34a2a77ba0673", size = 261370, upload-time = "2025-12-28T15:42:32.992Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2c/d31722f0ec918fd7453b2758312729f645978d212b410cd0f7c2aed88a94/coverage-7.13.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ee68b21909686eeb21dfcba2c3b81fee70dcf38b140dcd5aa70680995fa3aa5", size = 263485, upload-time = "2025-12-28T15:42:34.759Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7a/2c114fa5c5fc08ba0777e4aec4c97e0b4a1afcb69c75f1f54cff78b073ab/coverage-7.13.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:724b1b270cb13ea2e6503476e34541a0b1f62280bc997eab443f87790202033d", size = 265890, upload-time = "2025-12-28T15:42:36.517Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d9/f0794aa1c74ceabc780fe17f6c338456bbc4e96bd950f2e969f48ac6fb20/coverage-7.13.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:916abf1ac5cf7eb16bc540a5bf75c71c43a676f5c52fcb9fe75a2bd75fb944e8", size = 260445, upload-time = "2025-12-28T15:42:38.646Z" },
+    { url = "https://files.pythonhosted.org/packages/49/23/184b22a00d9bb97488863ced9454068c79e413cb23f472da6cbddc6cfc52/coverage-7.13.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:776483fd35b58d8afe3acbd9988d5de592ab6da2d2a865edfdbc9fdb43e7c486", size = 263357, upload-time = "2025-12-28T15:42:40.788Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/bd/58af54c0c9199ea4190284f389005779d7daf7bf3ce40dcd2d2b2f96da69/coverage-7.13.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:b6f3b96617e9852703f5b633ea01315ca45c77e879584f283c44127f0f1ec564", size = 260959, upload-time = "2025-12-28T15:42:42.808Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2a/6839294e8f78a4891bf1df79d69c536880ba2f970d0ff09e7513d6e352e9/coverage-7.13.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:bd63e7b74661fed317212fab774e2a648bc4bb09b35f25474f8e3325d2945cd7", size = 259792, upload-time = "2025-12-28T15:42:44.818Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c3/528674d4623283310ad676c5af7414b9850ab6d55c2300e8aa4b945ec554/coverage-7.13.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:933082f161bbb3e9f90d00990dc956120f608cdbcaeea15c4d897f56ef4fe416", size = 262123, upload-time = "2025-12-28T15:42:47.108Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c5/8c0515692fb4c73ac379d8dc09b18eaf0214ecb76ea6e62467ba7a1556ff/coverage-7.13.1-cp314-cp314t-win32.whl", hash = "sha256:18be793c4c87de2965e1c0f060f03d9e5aff66cfeae8e1dbe6e5b88056ec153f", size = 222562, upload-time = "2025-12-28T15:42:49.144Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0e/c0a0c4678cb30dac735811db529b321d7e1c9120b79bd728d4f4d6b010e9/coverage-7.13.1-cp314-cp314t-win_amd64.whl", hash = "sha256:0e42e0ec0cd3e0d851cb3c91f770c9301f48647cb2877cb78f74bdaa07639a79", size = 223670, upload-time = "2025-12-28T15:42:51.218Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/b177aa0011f354abf03a8f30a85032686d290fdeed4222b27d36b4372a50/coverage-7.13.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eaecf47ef10c72ece9a2a92118257da87e460e113b83cc0d2905cbbe931792b4", size = 221707, upload-time = "2025-12-28T15:42:53.034Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/48/d9f421cb8da5afaa1a64570d9989e00fb7955e6acddc5a12979f7666ef60/coverage-7.13.1-py3-none-any.whl", hash = "sha256:2016745cb3ba554469d02819d78958b571792bb68e31302610e898f80dd3a573", size = 210722, upload-time = "2025-12-28T15:42:54.901Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
 
 [[package]]
 name = "exceptiongroup"
@@ -68,6 +186,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "lefthook"
+version = "2.0.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/8f/e90724128f481c637b7e9343b6535622cfa136541959a49f8a3de0d0e7a5/lefthook-2.0.15.tar.gz", hash = "sha256:8a32c9f2d44f0ff0f3e3ab48f9802ca10f1222b491f3f14e03f577ec175b6649", size = 50175274, upload-time = "2026-01-13T10:02:58.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/d5/243d967f541d422a7252f92dbcc201cfd588bd404a66935baacc83be49c5/lefthook-2.0.15-py3-none-any.whl", hash = "sha256:54b174520f18a4fa2545ff1e5eae4c4d2515539fb25b8c4fe04b9224a2ff07ee", size = 50416709, upload-time = "2026-01-13T10:02:55.761Z" },
 ]
 
 [[package]]
@@ -113,6 +240,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
 ]
 
 [[package]]
@@ -177,6 +318,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.14.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/0a/1914efb7903174b381ee2ffeebb4253e729de57f114e63595114c8ca451f/ruff-0.14.13.tar.gz", hash = "sha256:83cd6c0763190784b99650a20fec7633c59f6ebe41c5cc9d45ee42749563ad47", size = 6059504, upload-time = "2026-01-15T20:15:16.918Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/ae/0deefbc65ca74b0ab1fd3917f94dc3b398233346a74b8bbb0a916a1a6bf6/ruff-0.14.13-py3-none-linux_armv6l.whl", hash = "sha256:76f62c62cd37c276cb03a275b198c7c15bd1d60c989f944db08a8c1c2dbec18b", size = 13062418, upload-time = "2026-01-15T20:14:50.779Z" },
+    { url = "https://files.pythonhosted.org/packages/47/df/5916604faa530a97a3c154c62a81cb6b735c0cb05d1e26d5ad0f0c8ac48a/ruff-0.14.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:914a8023ece0528d5cc33f5a684f5f38199bbb566a04815c2c211d8f40b5d0ed", size = 13442344, upload-time = "2026-01-15T20:15:07.94Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f3/e0e694dd69163c3a1671e102aa574a50357536f18a33375050334d5cd517/ruff-0.14.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d24899478c35ebfa730597a4a775d430ad0d5631b8647a3ab368c29b7e7bd063", size = 12354720, upload-time = "2026-01-15T20:15:09.854Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/e8/67f5fcbbaee25e8fc3b56cc33e9892eca7ffe09f773c8e5907757a7e3bdb/ruff-0.14.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9aaf3870f14d925bbaf18b8a2347ee0ae7d95a2e490e4d4aea6813ed15ebc80e", size = 12774493, upload-time = "2026-01-15T20:15:20.908Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ce/d2e9cb510870b52a9565d885c0d7668cc050e30fa2c8ac3fb1fda15c083d/ruff-0.14.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac5b7f63dd3b27cc811850f5ffd8fff845b00ad70e60b043aabf8d6ecc304e09", size = 12815174, upload-time = "2026-01-15T20:15:05.74Z" },
+    { url = "https://files.pythonhosted.org/packages/88/00/c38e5da58beebcf4fa32d0ddd993b63dfacefd02ab7922614231330845bf/ruff-0.14.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:78d2b1097750d90ba82ce4ba676e85230a0ed694178ca5e61aa9b459970b3eb9", size = 13680909, upload-time = "2026-01-15T20:15:14.537Z" },
+    { url = "https://files.pythonhosted.org/packages/61/61/cd37c9dd5bd0a3099ba79b2a5899ad417d8f3b04038810b0501a80814fd7/ruff-0.14.13-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:7d0bf87705acbbcb8d4c24b2d77fbb73d40210a95c3903b443cd9e30824a5032", size = 15144215, upload-time = "2026-01-15T20:15:22.886Z" },
+    { url = "https://files.pythonhosted.org/packages/56/8a/85502d7edbf98c2df7b8876f316c0157359165e16cdf98507c65c8d07d3d/ruff-0.14.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a3eb5da8e2c9e9f13431032fdcbe7681de9ceda5835efee3269417c13f1fed5c", size = 14706067, upload-time = "2026-01-15T20:14:48.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/2f/de0df127feb2ee8c1e54354dc1179b4a23798f0866019528c938ba439aca/ruff-0.14.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:642442b42957093811cd8d2140dfadd19c7417030a7a68cf8d51fcdd5f217427", size = 14133916, upload-time = "2026-01-15T20:14:57.357Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/77/9b99686bb9fe07a757c82f6f95e555c7a47801a9305576a9c67e0a31d280/ruff-0.14.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4acdf009f32b46f6e8864af19cbf6841eaaed8638e65c8dac845aea0d703c841", size = 13859207, upload-time = "2026-01-15T20:14:55.111Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/46/2bdcb34a87a179a4d23022d818c1c236cb40e477faf0d7c9afb6813e5876/ruff-0.14.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:591a7f68860ea4e003917d19b5c4f5ac39ff558f162dc753a2c5de897fd5502c", size = 14043686, upload-time = "2026-01-15T20:14:52.841Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/a9/5c6a4f56a0512c691cf143371bcf60505ed0f0860f24a85da8bd123b2bf1/ruff-0.14.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:774c77e841cc6e046fc3e91623ce0903d1cd07e3a36b1a9fe79b81dab3de506b", size = 12663837, upload-time = "2026-01-15T20:15:18.921Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/bb/b920016ece7651fa7fcd335d9d199306665486694d4361547ccb19394c44/ruff-0.14.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:61f4e40077a1248436772bb6512db5fc4457fe4c49e7a94ea7c5088655dd21ae", size = 12805867, upload-time = "2026-01-15T20:14:59.272Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b3/0bd909851e5696cd21e32a8fc25727e5f58f1934b3596975503e6e85415c/ruff-0.14.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6d02f1428357fae9e98ac7aa94b7e966fd24151088510d32cf6f902d6c09235e", size = 13208528, upload-time = "2026-01-15T20:15:03.732Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/3b/e2d94cb613f6bbd5155a75cbe072813756363eba46a3f2177a1fcd0cd670/ruff-0.14.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e399341472ce15237be0c0ae5fbceca4b04cd9bebab1a2b2c979e015455d8f0c", size = 13929242, upload-time = "2026-01-15T20:15:11.918Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c5/abd840d4132fd51a12f594934af5eba1d5d27298a6f5b5d6c3be45301caf/ruff-0.14.13-py3-none-win32.whl", hash = "sha256:ef720f529aec113968b45dfdb838ac8934e519711da53a0456038a0efecbd680", size = 12919024, upload-time = "2026-01-15T20:14:43.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/55/6384b0b8ce731b6e2ade2b5449bf07c0e4c31e8a2e68ea65b3bafadcecc5/ruff-0.14.13-py3-none-win_amd64.whl", hash = "sha256:6070bd026e409734b9257e03e3ef18c6e1a216f0435c6751d7a8ec69cb59abef", size = 14097887, upload-time = "2026-01-15T20:15:01.48Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/e1/7348090988095e4e39560cfc2f7555b1b2a7357deba19167b600fdf5215d/ruff-0.14.13-py3-none-win_arm64.whl", hash = "sha256:7ab819e14f1ad9fe39f246cfcc435880ef7a9390d81a2b6ac7e01039083dd247", size = 13080224, upload-time = "2026-01-15T20:14:45.853Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add ruff as the canonical Python linter and formatter, configured with pycodestyle, pyflakes, isort, bugbear, and pyupgrade rules
- Add lefthook for git hooks management with pre-commit validation
- Fix missing dependencies (tomli, tomli-w) and undefined imports in terminal adapters

## Pre-commit hooks
- `ruff-format` - checks code formatting on staged `.py` files
- `ruff-lint` - runs linter on staged `.py` files  
- `cli-smoke-test` - verifies CLI works (`--help` and `list` commands)
- `uv-lock-check` - ensures `uv.lock` is up to date when `pyproject.toml` changes

## Test plan
- [x] All 271 tests pass
- [x] Pre-commit hooks run successfully on commit
- [x] CLI smoke test passes
- [x] Code formatted with ruff

🤖 Generated with [Claude Code](https://claude.ai/code)