### PR TITLE
Add VSCode terminal adapter and fix missing tomli dependencies

### DIFF
--- a/console_cowboy/terminals/__init__.py
+++ b/console_cowboy/terminals/__init__.py
@@ -10,6 +10,7 @@ from .base import TerminalAdapter, TerminalRegistry
 from .ghostty import GhosttyAdapter
 from .iterm2 import ITerm2Adapter
 from .kitty import KittyAdapter
+from .vscode import VSCodeAdapter
 from .wezterm import WeztermAdapter
 
 # Register all adapters
@@ -18,6 +19,7 @@ TerminalRegistry.register(GhosttyAdapter)
 TerminalRegistry.register(AlacrittyAdapter)
 TerminalRegistry.register(KittyAdapter)
 TerminalRegistry.register(WeztermAdapter)
+TerminalRegistry.register(VSCodeAdapter)
 
 __all__ = [
     "TerminalAdapter",
@@ -27,4 +29,5 @@ __all__ = [
     "AlacrittyAdapter",
     "KittyAdapter",
     "WeztermAdapter",
+    "VSCodeAdapter",
 ]

--- a/console_cowboy/terminals/vscode.py
+++ b/console_cowboy/terminals/vscode.py
@@ -1,0 +1,369 @@
+"""
+VSCode terminal configuration adapter.
+
+VSCode stores terminal settings in its settings.json file, typically at:
+- macOS: ~/Library/Application Support/Code/User/settings.json
+- Linux: ~/.config/Code/User/settings.json
+- Windows: %APPDATA%/Code/User/settings.json
+
+Terminal colors are stored inside the workbench.colorCustomizations object.
+"""
+
+import json
+from pathlib import Path
+
+import click
+
+from console_cowboy.ctec.schema import (
+    CTEC,
+    BehaviorConfig,
+    ColorScheme,
+    CursorConfig,
+    CursorStyle,
+    FontConfig,
+    FontWeight,
+    ScrollConfig,
+)
+from console_cowboy.utils.colors import normalize_color
+
+from .base import TerminalAdapter
+
+
+class VSCodeAdapter(TerminalAdapter):
+    """
+    Adapter for Visual Studio Code integrated terminal.
+
+    VSCode uses JSON for configuration with terminal settings at
+    terminal.integrated.* keys and colors in workbench.colorCustomizations.
+    """
+
+    name = "vscode"
+    display_name = "Visual Studio Code"
+    description = "Microsoft's code editor with integrated terminal"
+    config_extensions = [".json"]
+    default_config_paths = [
+        # macOS
+        "Library/Application Support/Code/User/settings.json",
+        # Linux
+        ".config/Code/User/settings.json",
+        # Also check VSCode Insiders
+        "Library/Application Support/Code - Insiders/User/settings.json",
+        ".config/Code - Insiders/User/settings.json",
+    ]
+
+    # Cursor style mapping (VSCode uses 'line' for beam cursor)
+    CURSOR_STYLE_MAP = {
+        "block": CursorStyle.BLOCK,
+        "line": CursorStyle.BEAM,
+        "underline": CursorStyle.UNDERLINE,
+    }
+
+    CURSOR_STYLE_REVERSE_MAP = {v: k for k, v in CURSOR_STYLE_MAP.items()}
+
+    # Color key mapping from VSCode (inside workbench.colorCustomizations) to CTEC
+    COLOR_KEY_MAP = {
+        "terminal.foreground": "foreground",
+        "terminal.background": "background",
+        "terminal.selectionBackground": "selection",
+        "terminal.selectionForeground": "selection_text",
+        "terminalCursor.foreground": "cursor",
+        "terminalCursor.background": "cursor_text",
+        # ANSI colors
+        "terminal.ansiBlack": "black",
+        "terminal.ansiRed": "red",
+        "terminal.ansiGreen": "green",
+        "terminal.ansiYellow": "yellow",
+        "terminal.ansiBlue": "blue",
+        "terminal.ansiMagenta": "magenta",
+        "terminal.ansiCyan": "cyan",
+        "terminal.ansiWhite": "white",
+        "terminal.ansiBrightBlack": "bright_black",
+        "terminal.ansiBrightRed": "bright_red",
+        "terminal.ansiBrightGreen": "bright_green",
+        "terminal.ansiBrightYellow": "bright_yellow",
+        "terminal.ansiBrightBlue": "bright_blue",
+        "terminal.ansiBrightMagenta": "bright_magenta",
+        "terminal.ansiBrightCyan": "bright_cyan",
+        "terminal.ansiBrightWhite": "bright_white",
+    }
+
+    COLOR_KEY_REVERSE_MAP = {v: k for k, v in COLOR_KEY_MAP.items()}
+
+    # Keys we explicitly handle (not stored as terminal_specific)
+    _RECOGNIZED_KEYS = {
+        "terminal.integrated.fontFamily",
+        "terminal.integrated.fontSize",
+        "terminal.integrated.fontWeight",
+        "terminal.integrated.lineHeight",
+        "terminal.integrated.letterSpacing",
+        "terminal.integrated.fontLigatures",
+        "terminal.integrated.cursorStyle",
+        "terminal.integrated.cursorBlinking",
+        "terminal.integrated.scrollback",
+        "terminal.integrated.copyOnSelection",
+        "terminal.integrated.confirmOnExit",
+        "workbench.colorCustomizations",
+    }
+
+    @classmethod
+    def _parse_font_weight(cls, value: str | int) -> FontWeight | None:
+        """Convert VSCode font weight to CTEC FontWeight."""
+        if value is None:
+            return None
+        try:
+            if isinstance(value, int):
+                # Direct numeric weight
+                return FontWeight(value)
+            # String weight name
+            return FontWeight.from_string(str(value))
+        except ValueError:
+            return None
+
+    @classmethod
+    def parse(
+        cls,
+        source: str | Path,
+        *,
+        content: str | None = None,
+    ) -> CTEC:
+        """Parse VSCode settings.json containing terminal configuration."""
+        ctec = CTEC(source_terminal="vscode")
+
+        # Load JSON content
+        if content is None:
+            path = Path(source)
+            if not path.exists():
+                raise FileNotFoundError(f"Config file not found: {path}")
+            content = path.read_text()
+
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON: {e}") from e
+
+        # Parse font settings
+        font = FontConfig()
+        font_modified = False
+
+        if "terminal.integrated.fontFamily" in data:
+            font.family = data["terminal.integrated.fontFamily"]
+            font_modified = True
+
+        if "terminal.integrated.fontSize" in data:
+            try:
+                font.size = float(data["terminal.integrated.fontSize"])
+                font_modified = True
+            except (ValueError, TypeError):
+                ctec.add_warning(
+                    f"Invalid fontSize: {data['terminal.integrated.fontSize']}"
+                )
+
+        if "terminal.integrated.fontWeight" in data:
+            weight = cls._parse_font_weight(data["terminal.integrated.fontWeight"])
+            if weight:
+                font.weight = weight
+                font_modified = True
+            else:
+                ctec.add_warning(
+                    f"Invalid fontWeight: {data['terminal.integrated.fontWeight']}"
+                )
+
+        if "terminal.integrated.lineHeight" in data:
+            try:
+                font.line_height = float(data["terminal.integrated.lineHeight"])
+                font_modified = True
+            except (ValueError, TypeError):
+                ctec.add_warning(
+                    f"Invalid lineHeight: {data['terminal.integrated.lineHeight']}"
+                )
+
+        if "terminal.integrated.letterSpacing" in data:
+            try:
+                # letterSpacing is in pixels, convert to cell_width multiplier
+                # Approximate: +1px spacing ~ +0.1 cell_width
+                spacing = float(data["terminal.integrated.letterSpacing"])
+                font.cell_width = 1.0 + (spacing / 10.0)
+                font_modified = True
+            except (ValueError, TypeError):
+                ctec.add_warning(
+                    f"Invalid letterSpacing: {data['terminal.integrated.letterSpacing']}"
+                )
+
+        if "terminal.integrated.fontLigatures" in data:
+            ligatures_val = data["terminal.integrated.fontLigatures"]
+            # Can be boolean or CSS font-feature-settings string
+            if isinstance(ligatures_val, bool):
+                font.ligatures = ligatures_val
+            else:
+                # String means enabled with specific features
+                font.ligatures = True
+                ctec.add_terminal_specific(
+                    "vscode", "terminal.integrated.fontLigatures", ligatures_val
+                )
+            font_modified = True
+
+        if font_modified:
+            ctec.font = font
+
+        # Parse cursor settings
+        cursor = CursorConfig()
+        cursor_modified = False
+
+        if "terminal.integrated.cursorStyle" in data:
+            style_str = data["terminal.integrated.cursorStyle"]
+            cursor.style = cls.CURSOR_STYLE_MAP.get(style_str, CursorStyle.BLOCK)
+            cursor_modified = True
+
+        if "terminal.integrated.cursorBlinking" in data:
+            cursor.blink = bool(data["terminal.integrated.cursorBlinking"])
+            cursor_modified = True
+
+        if cursor_modified:
+            ctec.cursor = cursor
+
+        # Parse colors from workbench.colorCustomizations
+        if "workbench.colorCustomizations" in data:
+            color_customs = data["workbench.colorCustomizations"]
+            if isinstance(color_customs, dict):
+                scheme = ColorScheme()
+                scheme_modified = False
+
+                for vscode_key, ctec_attr in cls.COLOR_KEY_MAP.items():
+                    if vscode_key in color_customs:
+                        try:
+                            color = normalize_color(color_customs[vscode_key])
+                            setattr(scheme, ctec_attr, color)
+                            scheme_modified = True
+                        except (ValueError, TypeError):
+                            ctec.add_warning(f"Invalid color for {vscode_key}")
+
+                if scheme_modified:
+                    ctec.color_scheme = scheme
+
+        # Parse scroll settings
+        if "terminal.integrated.scrollback" in data:
+            try:
+                lines = int(data["terminal.integrated.scrollback"])
+                ctec.scroll = ScrollConfig.from_lines(lines)
+            except (ValueError, TypeError):
+                ctec.add_warning(
+                    f"Invalid scrollback: {data['terminal.integrated.scrollback']}"
+                )
+
+        # Parse behavior settings
+        behavior = BehaviorConfig()
+        behavior_modified = False
+
+        if "terminal.integrated.copyOnSelection" in data:
+            behavior.copy_on_select = bool(data["terminal.integrated.copyOnSelection"])
+            behavior_modified = True
+
+        if "terminal.integrated.confirmOnExit" in data:
+            confirm_val = data["terminal.integrated.confirmOnExit"]
+            # VSCode uses "never", "always", "hasChildProcesses"
+            behavior.confirm_close = confirm_val != "never"
+            behavior_modified = True
+
+        if behavior_modified:
+            ctec.behavior = behavior
+
+        # Store VSCode-specific settings that have no CTEC equivalent
+        for key in data:
+            if (
+                key.startswith("terminal.integrated.")
+                and key not in cls._RECOGNIZED_KEYS
+            ):
+                ctec.add_terminal_specific("vscode", key, data[key])
+
+        return ctec
+
+    @classmethod
+    def export(cls, ctec: CTEC) -> str:
+        """
+        Export CTEC to VSCode settings.json format.
+
+        Returns a JSON object containing only terminal-related settings.
+        Users should merge this into their existing settings.json.
+
+        Note: Colors are exported inside workbench.colorCustomizations.
+        """
+        result = {}
+
+        # Export font settings
+        if ctec.font:
+            if ctec.font.family:
+                result["terminal.integrated.fontFamily"] = ctec.font.family
+            if ctec.font.size:
+                result["terminal.integrated.fontSize"] = ctec.font.size
+            if ctec.font.weight:
+                result["terminal.integrated.fontWeight"] = ctec.font.weight.value
+            if ctec.font.line_height:
+                result["terminal.integrated.lineHeight"] = ctec.font.line_height
+            if ctec.font.cell_width and ctec.font.cell_width != 1.0:
+                # Convert cell_width back to letterSpacing (approximate)
+                spacing = int((ctec.font.cell_width - 1.0) * 10)
+                result["terminal.integrated.letterSpacing"] = spacing
+            if ctec.font.ligatures is not None:
+                result["terminal.integrated.fontLigatures"] = ctec.font.ligatures
+
+        # Export cursor settings
+        if ctec.cursor:
+            if ctec.cursor.style:
+                result["terminal.integrated.cursorStyle"] = (
+                    cls.CURSOR_STYLE_REVERSE_MAP.get(ctec.cursor.style, "block")
+                )
+            if ctec.cursor.blink is not None:
+                result["terminal.integrated.cursorBlinking"] = ctec.cursor.blink
+
+        # Export colors inside workbench.colorCustomizations
+        if ctec.color_scheme:
+            color_customs = {}
+            for ctec_attr, vscode_key in cls.COLOR_KEY_REVERSE_MAP.items():
+                color = getattr(ctec.color_scheme, ctec_attr, None)
+                if color:
+                    color_customs[vscode_key] = color.to_hex()
+
+            if color_customs:
+                result["workbench.colorCustomizations"] = color_customs
+
+        # Export scroll settings
+        if ctec.scroll:
+            lines = ctec.scroll.get_effective_lines(default=1000, max_lines=100000)
+            result["terminal.integrated.scrollback"] = lines
+
+        # Export behavior settings
+        if ctec.behavior:
+            if ctec.behavior.copy_on_select is not None:
+                result["terminal.integrated.copyOnSelection"] = (
+                    ctec.behavior.copy_on_select
+                )
+            if ctec.behavior.confirm_close is not None:
+                result["terminal.integrated.confirmOnExit"] = (
+                    "always" if ctec.behavior.confirm_close else "never"
+                )
+
+        # Restore VSCode-specific settings
+        for setting in ctec.get_terminal_specific("vscode"):
+            result[setting.key] = setting.value
+
+        # Print informational message to stderr
+        click.echo(
+            click.style("\nVSCode Export Notes:", fg="cyan", bold=True),
+            err=True,
+        )
+        click.echo(
+            click.style(
+                "  This output contains terminal settings that should be merged\n"
+                "  into your VSCode settings.json file. You can either:\n"
+                "    1. Copy these settings manually into your settings.json\n"
+                "    2. Use 'Code > Preferences > Settings' (JSON mode) to merge\n"
+                "\n"
+                "  Note: Colors are inside 'workbench.colorCustomizations'.\n"
+                "  If you already have colorCustomizations, merge the terminal\n"
+                "  colors into your existing object.",
+                dim=True,
+            ),
+            err=True,
+        )
+
+        return json.dumps(result, indent=2)

--- a/tests/fixtures/vscode/settings.json
+++ b/tests/fixtures/vscode/settings.json
@@ -1,0 +1,44 @@
+{
+    "terminal.integrated.fontFamily": "JetBrains Mono",
+    "terminal.integrated.fontSize": 14,
+    "terminal.integrated.fontWeight": "normal",
+    "terminal.integrated.lineHeight": 1.2,
+    "terminal.integrated.letterSpacing": 0,
+    "terminal.integrated.fontLigatures": true,
+    "terminal.integrated.cursorStyle": "block",
+    "terminal.integrated.cursorBlinking": true,
+    "terminal.integrated.cursorWidth": 2,
+    "terminal.integrated.scrollback": 10000,
+    "terminal.integrated.copyOnSelection": true,
+    "terminal.integrated.confirmOnExit": "hasChildProcesses",
+    "terminal.integrated.defaultProfile.osx": "zsh",
+    "terminal.integrated.profiles.osx": {
+        "zsh": {
+            "path": "/bin/zsh"
+        }
+    },
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#c5c8c6",
+        "terminal.background": "#1d1f21",
+        "terminal.selectionBackground": "#373b41",
+        "terminal.selectionForeground": "#c5c8c6",
+        "terminalCursor.foreground": "#c5c8c6",
+        "terminalCursor.background": "#1d1f21",
+        "terminal.ansiBlack": "#1d1f21",
+        "terminal.ansiRed": "#cc6666",
+        "terminal.ansiGreen": "#b5bd68",
+        "terminal.ansiYellow": "#f0c674",
+        "terminal.ansiBlue": "#81a2be",
+        "terminal.ansiMagenta": "#b294bb",
+        "terminal.ansiCyan": "#8abeb7",
+        "terminal.ansiWhite": "#c5c8c6",
+        "terminal.ansiBrightBlack": "#969896",
+        "terminal.ansiBrightRed": "#cc6666",
+        "terminal.ansiBrightGreen": "#b5bd68",
+        "terminal.ansiBrightYellow": "#f0c674",
+        "terminal.ansiBrightBlue": "#81a2be",
+        "terminal.ansiBrightMagenta": "#b294bb",
+        "terminal.ansiBrightCyan": "#8abeb7",
+        "terminal.ansiBrightWhite": "#ffffff"
+    }
+}

--- a/tests/test_terminals.py
+++ b/tests/test_terminals.py
@@ -18,6 +18,7 @@ from console_cowboy.terminals import (
     ITerm2Adapter,
     KittyAdapter,
     TerminalRegistry,
+    VSCodeAdapter,
     WeztermAdapter,
 )
 
@@ -34,6 +35,7 @@ class TestTerminalRegistry:
         assert "alacritty" in names
         assert "kitty" in names
         assert "wezterm" in names
+        assert "vscode" in names
 
     def test_get_terminal_by_name(self):
         adapter = TerminalRegistry.get("ghostty")
@@ -49,8 +51,9 @@ class TestTerminalRegistry:
 
     def test_list_terminals(self):
         terminals = TerminalRegistry.list_terminals()
-        assert len(terminals) == 5
+        assert len(terminals) == 6
         assert ITerm2Adapter in terminals
+        assert VSCodeAdapter in terminals
 
 
 class TestGhosttyAdapter:
@@ -453,3 +456,153 @@ class TestCrossTerminalConversion:
         assert ghostty_ctec.color_scheme.foreground.r == 197
         assert ghostty_ctec.color_scheme.foreground.g == 200
         assert ghostty_ctec.color_scheme.foreground.b == 198
+
+
+class TestVSCodeAdapter:
+    """Tests for the VSCode adapter."""
+
+    def test_adapter_metadata(self):
+        assert VSCodeAdapter.name == "vscode"
+        assert VSCodeAdapter.display_name == "Visual Studio Code"
+        assert ".json" in VSCodeAdapter.config_extensions
+
+    def test_parse_fixture(self):
+        config_path = FIXTURES_DIR / "vscode" / "settings.json"
+        ctec = VSCodeAdapter.parse(config_path)
+
+        assert ctec.source_terminal == "vscode"
+        assert ctec.font.family == "JetBrains Mono"
+        assert ctec.font.size == 14.0
+        assert ctec.cursor.style == CursorStyle.BLOCK
+        assert ctec.cursor.blink is True
+
+    def test_parse_colors(self):
+        config_path = FIXTURES_DIR / "vscode" / "settings.json"
+        ctec = VSCodeAdapter.parse(config_path)
+
+        assert ctec.color_scheme is not None
+        # Check foreground (#c5c8c6)
+        assert ctec.color_scheme.foreground.r == 197
+        assert ctec.color_scheme.foreground.g == 200
+        assert ctec.color_scheme.foreground.b == 198
+        # Check background (#1d1f21)
+        assert ctec.color_scheme.background.r == 29
+        assert ctec.color_scheme.background.g == 31
+        assert ctec.color_scheme.background.b == 33
+
+    def test_parse_scroll(self):
+        config_path = FIXTURES_DIR / "vscode" / "settings.json"
+        ctec = VSCodeAdapter.parse(config_path)
+
+        assert ctec.scroll is not None
+        assert ctec.scroll.lines == 10000
+
+    def test_parse_behavior(self):
+        config_path = FIXTURES_DIR / "vscode" / "settings.json"
+        ctec = VSCodeAdapter.parse(config_path)
+
+        assert ctec.behavior is not None
+        assert ctec.behavior.copy_on_select is True
+
+    def test_parse_from_content(self):
+        content = """
+{
+    "terminal.integrated.fontFamily": "Fira Code",
+    "terminal.integrated.fontSize": 16,
+    "terminal.integrated.cursorStyle": "line"
+}
+"""
+        ctec = VSCodeAdapter.parse("test.json", content=content)
+        assert ctec.font.family == "Fira Code"
+        assert ctec.font.size == 16.0
+        assert ctec.cursor.style == CursorStyle.BEAM
+
+    def test_export(self):
+        import json
+
+        ctec = CTEC(
+            font=FontConfig(family="Fira Code", size=12.0),
+            cursor=CursorConfig(style=CursorStyle.BEAM, blink=False),
+        )
+        output = VSCodeAdapter.export(ctec)
+        data = json.loads(output)
+
+        assert data["terminal.integrated.fontFamily"] == "Fira Code"
+        assert data["terminal.integrated.fontSize"] == 12.0
+        assert data["terminal.integrated.cursorStyle"] == "line"
+        assert data["terminal.integrated.cursorBlinking"] is False
+
+    def test_export_colors(self):
+        import json
+
+        ctec = CTEC(
+            color_scheme=ColorScheme(
+                foreground=Color(255, 255, 255),
+                background=Color(0, 0, 0),
+            )
+        )
+        output = VSCodeAdapter.export(ctec)
+        data = json.loads(output)
+
+        assert "workbench.colorCustomizations" in data
+        colors = data["workbench.colorCustomizations"]
+        assert colors["terminal.foreground"] == "#ffffff"
+        assert colors["terminal.background"] == "#000000"
+
+    def test_export_produces_valid_json(self):
+        import json
+
+        ctec = CTEC(
+            font=FontConfig(family="Test Font", size=14.0),
+        )
+        output = VSCodeAdapter.export(ctec)
+        # Should not raise
+        data = json.loads(output)
+        assert isinstance(data, dict)
+
+    def test_roundtrip(self):
+        config_path = FIXTURES_DIR / "vscode" / "settings.json"
+        original = VSCodeAdapter.parse(config_path)
+
+        exported = VSCodeAdapter.export(original)
+        restored = VSCodeAdapter.parse("test.json", content=exported)
+
+        assert restored.font.family == original.font.family
+        assert restored.font.size == original.font.size
+        assert restored.cursor.style == original.cursor.style
+
+    def test_terminal_specific_settings(self):
+        config_path = FIXTURES_DIR / "vscode" / "settings.json"
+        ctec = VSCodeAdapter.parse(config_path)
+
+        vscode_specific = ctec.get_terminal_specific("vscode")
+        # cursorWidth should be stored as terminal-specific
+        cursor_width = next(
+            (s for s in vscode_specific if s.key == "terminal.integrated.cursorWidth"),
+            None,
+        )
+        assert cursor_width is not None
+        assert cursor_width.value == 2
+
+    def test_ghostty_to_vscode(self):
+        """Test converting from Ghostty to VSCode."""
+
+        ghostty_path = FIXTURES_DIR / "ghostty" / "config"
+        ctec = GhosttyAdapter.parse(ghostty_path)
+
+        vscode_output = VSCodeAdapter.export(ctec)
+        vscode_ctec = VSCodeAdapter.parse("test.json", content=vscode_output)
+
+        assert vscode_ctec.font.family == ctec.font.family
+        assert vscode_ctec.font.size == ctec.font.size
+
+    def test_vscode_to_ghostty(self):
+        """Test converting from VSCode to Ghostty."""
+        vscode_path = FIXTURES_DIR / "vscode" / "settings.json"
+        ctec = VSCodeAdapter.parse(vscode_path)
+
+        ghostty_output = GhosttyAdapter.export(ctec)
+        ghostty_ctec = GhosttyAdapter.parse("test", content=ghostty_output)
+
+        assert ghostty_ctec.font.family == ctec.font.family
+        assert ghostty_ctec.font.size == ctec.font.size


### PR DESCRIPTION
## Summary

- Add `VSCodeAdapter` for importing/exporting VS Code integrated terminal settings
- Export produces a JSON file of settings to be merged into the user's `settings.json`
- Fix missing `tomli` and `tomli-w` dependencies in `pyproject.toml` (were used by Alacritty adapter but undeclared)

## VSCode Settings Mapped

| Category | Settings |
|----------|----------|
| **Font** | fontFamily, fontSize, fontWeight, lineHeight, letterSpacing, fontLigatures |
| **Cursor** | cursorStyle (block/line/underline), cursorBlinking |
| **Colors** | 16 ANSI colors + foreground/background/cursor/selection via `workbench.colorCustomizations` |
| **Scroll** | scrollback (line-based) |
| **Behavior** | copyOnSelection, confirmOnExit |

## Export Behavior

When exporting to VSCode, users see guidance on stderr:
```
VSCode Export Notes:
  This output contains terminal settings that should be merged
  into your VSCode settings.json file...
```

## Known Limitations

Per terminal advocate feedback, VSCode's integrated terminal is more limited than dedicated emulators. Settings that cannot be represented (bold color, window opacity, keybindings, etc.) are silently dropped. Future work could add warnings for these cases.

## Test plan

- [x] `python -m pytest tests/test_terminals.py -k vscode -v` - 13 tests pass
- [x] `python -m pytest` - All 284 tests pass
- [x] `console-cowboy list` shows vscode
- [x] `console-cowboy convert fixtures/ghostty/config -f ghostty -t vscode` works
- [x] `console-cowboy convert fixtures/vscode/settings.json -f vscode -t ghostty` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)