### PR TITLE
fix: allow manual trigger for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,10 @@
 name: Publish Python Package
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       tag_name:
-        description: 'The tag name for the release'
+        description: 'The tag name for the release (e.g., v0.1.2)'
         required: true
         type: string
 


### PR DESCRIPTION
Allows manually triggering a PyPI publish for a specific tag.