### PR TITLE
fix(ci): switch to MishaKav/pytest-coverage-comment action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,36 +23,15 @@ jobs:
     - name: Install dependencies
       run: uv sync
     - name: Run tests with coverage
-      run: uv run python -m pytest
-    - name: Upload coverage artifact
-      if: matrix.python-version == '3.12'
-      uses: actions/upload-artifact@v4
+      run: |
+        uv run python -m pytest \
+          --junitxml=pytest.xml \
+          --cov-report=term-missing:skip-covered \
+          --cov=console_cowboy \
+          | tee pytest-coverage.txt
+    - name: Pytest coverage comment
+      if: matrix.python-version == '3.12' && github.event_name == 'pull_request'
+      uses: MishaKav/pytest-coverage-comment@main
       with:
-        name: coverage-report
-        path: |
-          coverage.xml
-          htmlcov/
-        retention-days: 7
-
-  coverage-comment:
-    needs: test
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    permissions:
-      # Gives the action the necessary permissions for publishing new
-      # comments in pull requests.
-      pull-requests: write
-      # Gives the action the necessary permissions for pushing data to the
-      # python-coverage-comment-action branch, and for editing existing
-      # comments (to avoid publishing multiple comments in the same PR)
-      contents: write
-    steps:
-    - uses: actions/checkout@v5
-    - name: Download coverage artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: coverage-report
-    - name: Coverage comment
-      uses: py-cov-action/python-coverage-comment-action@v3
-      with:
-        GITHUB_TOKEN: ${{ github.token }}
+        pytest-coverage-path: ./pytest-coverage.txt
+        junitxml-path: ./pytest.xml


### PR DESCRIPTION
## Summary

- Fixes the failing coverage comment action by switching from `py-cov-action/python-coverage-comment-action` to `MishaKav/pytest-coverage-comment`
- Adds proper pytest coverage flags (`--cov`, `--cov-report`, `--junitxml`) that were missing
- Simplifies the workflow by removing the separate `coverage-comment` job and artifact upload/download

## Problem

The previous action required the `coverage` command to be installed, but the `coverage-comment` job ran in a fresh environment without Python dependencies installed.

## Solution

The new action works directly with pytest output files (text coverage report and junit XML), eliminating the need for the `coverage` command.

## Test plan

- [ ] Verify this PR receives a coverage comment from the new action

🤖 Generated with [Claude Code](https://claude.com/claude-code)