### PR TITLE
feat(ghostty): convert iTerm2 hotkey window hotkey to Ghostty keybind

### DIFF
--- a/console_cowboy/terminals/ghostty.py
+++ b/console_cowboy/terminals/ghostty.py
@@ -28,6 +28,7 @@ from console_cowboy.ctec.schema import (
     WindowConfig,
 )
 from console_cowboy.utils.colors import normalize_color
+from console_cowboy.utils.keycodes import macos_hotkey_to_keybind
 
 from .base import TerminalAdapter
 from .mixins import ColorMapMixin, CursorStyleMixin, ParsingMixin
@@ -804,6 +805,24 @@ class GhosttyAdapter(TerminalAdapter, CursorStyleMixin, ColorMapMixin, ParsingMi
                     f"quick-terminal-autohide = "
                     f"{str(ctec.quick_terminal.hide_on_focus_loss).lower()}"
                 )
+            # Export quick terminal hotkey as a global keybinding
+            # This converts iTerm2's numeric key code + modifiers to Ghostty format
+            if (
+                ctec.quick_terminal.hotkey_key_code is not None
+                or ctec.quick_terminal.hotkey_modifiers is not None
+            ):
+                keybind_str = macos_hotkey_to_keybind(
+                    ctec.quick_terminal.hotkey_key_code,
+                    ctec.quick_terminal.hotkey_modifiers,
+                )
+                if keybind_str:
+                    lines.append(f"keybind = {keybind_str}")
+                else:
+                    ctec.add_warning(
+                        f"Could not convert quick terminal hotkey (key code: "
+                        f"{ctec.quick_terminal.hotkey_key_code}) to keybinding. "
+                        "You may need to manually configure the global keybind."
+                    )
             lines.append("")
 
         # Export tab settings

--- a/console_cowboy/utils/keycodes.py
+++ b/console_cowboy/utils/keycodes.py
@@ -1,0 +1,205 @@
+"""
+Utilities for converting macOS virtual key codes and modifier flags.
+
+macOS uses virtual key codes (integers) to represent physical keys, and
+NSEventModifierFlags (bitmask) for modifier keys. This module provides
+mappings to convert these to standard key names used by terminal emulators.
+
+Reference:
+- Virtual key codes: Carbon/Events.h kVK_* constants
+- Modifier flags: Cocoa/NSEvent.h NSEventModifierFlags
+"""
+
+# macOS virtual key codes to key names
+# Based on Carbon Events.h kVK_* constants
+# Key names follow Ghostty/common terminal conventions
+MACOS_KEYCODE_MAP: dict[int, str] = {
+    # Letters (QWERTY layout)
+    0: "a",
+    1: "s",
+    2: "d",
+    3: "f",
+    4: "h",
+    5: "g",
+    6: "z",
+    7: "x",
+    8: "c",
+    9: "v",
+    11: "b",
+    12: "q",
+    13: "w",
+    14: "e",
+    15: "r",
+    16: "y",
+    17: "t",
+    18: "one",  # Number row
+    19: "two",
+    20: "three",
+    21: "four",
+    22: "six",
+    23: "five",
+    24: "equal",
+    25: "nine",
+    26: "seven",
+    27: "minus",
+    28: "eight",
+    29: "zero",
+    30: "right_bracket",
+    31: "o",
+    32: "u",
+    33: "left_bracket",
+    34: "i",
+    35: "p",
+    36: "Return",
+    37: "l",
+    38: "j",
+    39: "apostrophe",
+    40: "k",
+    41: "semicolon",
+    42: "backslash",
+    43: "comma",
+    44: "slash",
+    45: "n",
+    46: "m",
+    47: "period",
+    48: "Tab",
+    49: "space",
+    50: "grave",  # Backtick/grave accent
+    51: "Backspace",
+    53: "Escape",
+    # Function keys
+    96: "F5",
+    97: "F6",
+    98: "F7",
+    99: "F3",
+    100: "F8",
+    101: "F9",
+    103: "F11",
+    105: "F13",
+    107: "F14",
+    109: "F10",
+    111: "F12",
+    113: "F15",
+    118: "F4",
+    119: "End",
+    120: "F2",
+    121: "Page_Down",
+    122: "F1",
+    123: "Left",
+    124: "Right",
+    125: "Down",
+    126: "Up",
+    115: "Home",
+    116: "Page_Up",
+    117: "Delete",  # Forward delete
+    # Keypad
+    65: "KP_Decimal",
+    67: "KP_Multiply",
+    69: "KP_Add",
+    71: "KP_Clear",
+    75: "KP_Divide",
+    76: "KP_Enter",
+    78: "KP_Subtract",
+    81: "KP_Equal",
+    82: "KP_0",
+    83: "KP_1",
+    84: "KP_2",
+    85: "KP_3",
+    86: "KP_4",
+    87: "KP_5",
+    88: "KP_6",
+    89: "KP_7",
+    91: "KP_8",
+    92: "KP_9",
+}
+
+# macOS NSEventModifierFlags bitmask values
+# Reference: NSEvent.h
+MACOS_MODIFIER_CAPS_LOCK = 1 << 16  # 65536
+MACOS_MODIFIER_SHIFT = 1 << 17  # 131072
+MACOS_MODIFIER_CONTROL = 1 << 18  # 262144
+MACOS_MODIFIER_OPTION = 1 << 19  # 524288 (Alt)
+MACOS_MODIFIER_COMMAND = 1 << 20  # 1048576 (Super/Cmd)
+MACOS_MODIFIER_FUNCTION = 1 << 23  # 8388608
+
+# Mapping of modifier flags to standard modifier names
+# Order matters: ctrl, shift, alt/opt, super/cmd is conventional
+MACOS_MODIFIER_MAP: list[tuple[int, str]] = [
+    (MACOS_MODIFIER_CONTROL, "ctrl"),
+    (MACOS_MODIFIER_SHIFT, "shift"),
+    (MACOS_MODIFIER_OPTION, "alt"),
+    (MACOS_MODIFIER_COMMAND, "super"),
+]
+
+
+def keycode_to_name(keycode: int) -> str | None:
+    """
+    Convert a macOS virtual key code to a key name.
+
+    Args:
+        keycode: macOS virtual key code (e.g., 7 for 'x')
+
+    Returns:
+        Key name string (e.g., 'x', 'Return', 'F1') or None if unknown
+    """
+    return MACOS_KEYCODE_MAP.get(keycode)
+
+
+def modifiers_to_list(modifier_flags: int | None) -> list[str]:
+    """
+    Convert macOS NSEventModifierFlags to a list of modifier names.
+
+    Args:
+        modifier_flags: Bitmask of modifier flags (e.g., 1441792), or None
+
+    Returns:
+        List of modifier names in conventional order (e.g., ['ctrl', 'shift', 'super'])
+    """
+    if modifier_flags is None:
+        return []
+    mods = []
+    for flag, name in MACOS_MODIFIER_MAP:
+        if modifier_flags & flag:
+            mods.append(name)
+    return mods
+
+
+def macos_hotkey_to_keybind(
+    key_code: int | None,
+    modifier_flags: int | None,
+    action: str = "toggle_quick_terminal",
+    scope: str = "global",
+) -> str | None:
+    """
+    Convert macOS hotkey (key code + modifiers) to a terminal keybind string.
+
+    Args:
+        key_code: macOS virtual key code
+        modifier_flags: macOS NSEventModifierFlags bitmask
+        action: Action name for the keybinding
+        scope: Keybinding scope (e.g., 'global', 'application')
+
+    Returns:
+        Keybind string in Ghostty format (e.g., 'global:ctrl+shift+super+x=toggle_quick_terminal')
+        or None if key_code is unknown
+    """
+    if key_code is None:
+        return None
+
+    key_name = keycode_to_name(key_code)
+    if key_name is None:
+        return None
+
+    # Build modifier prefix
+    mods = modifiers_to_list(modifier_flags or 0)
+
+    # Build the key combination string
+    if mods:
+        key_combo = "+".join(mods + [key_name])
+    else:
+        key_combo = key_name
+
+    # Build the full keybind string
+    if scope and scope != "application":
+        return f"{scope}:{key_combo}={action}"
+    return f"{key_combo}={action}"

--- a/tests/test_terminals.py
+++ b/tests/test_terminals.py
@@ -3088,3 +3088,208 @@ url_color #0087ff
         )
         assert "macos_option_as_alt yes" in output
         assert "url_color #0087ff" in output
+
+
+class TestMacOSKeyCodeConversion:
+    """Tests for macOS key code and modifier conversion utilities."""
+
+    def test_keycode_to_name_letters(self):
+        """Test conversion of letter key codes."""
+        from console_cowboy.utils.keycodes import keycode_to_name
+
+        assert keycode_to_name(0) == "a"
+        assert keycode_to_name(7) == "x"
+        assert keycode_to_name(12) == "q"
+        assert keycode_to_name(35) == "p"
+
+    def test_keycode_to_name_special_keys(self):
+        """Test conversion of special key codes."""
+        from console_cowboy.utils.keycodes import keycode_to_name
+
+        assert keycode_to_name(36) == "Return"
+        assert keycode_to_name(48) == "Tab"
+        assert keycode_to_name(49) == "space"
+        assert keycode_to_name(50) == "grave"  # Backtick
+        assert keycode_to_name(53) == "Escape"
+
+    def test_keycode_to_name_function_keys(self):
+        """Test conversion of function key codes."""
+        from console_cowboy.utils.keycodes import keycode_to_name
+
+        assert keycode_to_name(122) == "F1"
+        assert keycode_to_name(120) == "F2"
+        assert keycode_to_name(111) == "F12"
+
+    def test_keycode_to_name_unknown(self):
+        """Test that unknown key codes return None."""
+        from console_cowboy.utils.keycodes import keycode_to_name
+
+        assert keycode_to_name(999) is None
+        assert keycode_to_name(-1) is None
+
+    def test_modifiers_to_list_single(self):
+        """Test conversion of single modifier flags."""
+        from console_cowboy.utils.keycodes import (
+            MACOS_MODIFIER_COMMAND,
+            MACOS_MODIFIER_CONTROL,
+            MACOS_MODIFIER_OPTION,
+            MACOS_MODIFIER_SHIFT,
+            modifiers_to_list,
+        )
+
+        assert modifiers_to_list(MACOS_MODIFIER_CONTROL) == ["ctrl"]
+        assert modifiers_to_list(MACOS_MODIFIER_SHIFT) == ["shift"]
+        assert modifiers_to_list(MACOS_MODIFIER_OPTION) == ["alt"]
+        assert modifiers_to_list(MACOS_MODIFIER_COMMAND) == ["super"]
+
+    def test_modifiers_to_list_combined(self):
+        """Test conversion of combined modifier flags."""
+        from console_cowboy.utils.keycodes import (
+            MACOS_MODIFIER_COMMAND,
+            MACOS_MODIFIER_CONTROL,
+            MACOS_MODIFIER_SHIFT,
+            modifiers_to_list,
+        )
+
+        # Ctrl+Shift+Cmd (1441792 from user's iTerm2 config)
+        combined = (
+            MACOS_MODIFIER_CONTROL | MACOS_MODIFIER_SHIFT | MACOS_MODIFIER_COMMAND
+        )
+        assert combined == 1441792
+        mods = modifiers_to_list(combined)
+        assert mods == ["ctrl", "shift", "super"]
+
+    def test_modifiers_to_list_empty(self):
+        """Test conversion of no modifiers."""
+        from console_cowboy.utils.keycodes import modifiers_to_list
+
+        assert modifiers_to_list(0) == []
+        assert modifiers_to_list(None) == []
+
+    def test_macos_hotkey_to_keybind_basic(self):
+        """Test full hotkey to keybind conversion."""
+        from console_cowboy.utils.keycodes import macos_hotkey_to_keybind
+
+        # Ctrl+Shift+Cmd+X (user's actual hotkey)
+        result = macos_hotkey_to_keybind(7, 1441792)
+        assert result == "global:ctrl+shift+super+x=toggle_quick_terminal"
+
+    def test_macos_hotkey_to_keybind_grave(self):
+        """Test conversion with grave/backtick key."""
+        from console_cowboy.utils.keycodes import (
+            MACOS_MODIFIER_CONTROL,
+            macos_hotkey_to_keybind,
+        )
+
+        result = macos_hotkey_to_keybind(50, MACOS_MODIFIER_CONTROL)
+        assert result == "global:ctrl+grave=toggle_quick_terminal"
+
+    def test_macos_hotkey_to_keybind_no_modifiers(self):
+        """Test conversion with no modifiers."""
+        from console_cowboy.utils.keycodes import macos_hotkey_to_keybind
+
+        result = macos_hotkey_to_keybind(122, 0)  # F1
+        assert result == "global:F1=toggle_quick_terminal"
+
+    def test_macos_hotkey_to_keybind_unknown_keycode(self):
+        """Test conversion with unknown key code returns None."""
+        from console_cowboy.utils.keycodes import macos_hotkey_to_keybind
+
+        result = macos_hotkey_to_keybind(999, 0)
+        assert result is None
+
+    def test_macos_hotkey_to_keybind_custom_action(self):
+        """Test conversion with custom action."""
+        from console_cowboy.utils.keycodes import macos_hotkey_to_keybind
+
+        result = macos_hotkey_to_keybind(7, 0, action="custom_action")
+        assert result == "global:x=custom_action"
+
+    def test_macos_hotkey_to_keybind_application_scope(self):
+        """Test conversion with application scope."""
+        from console_cowboy.utils.keycodes import macos_hotkey_to_keybind
+
+        result = macos_hotkey_to_keybind(7, 0, scope="application")
+        assert result == "x=toggle_quick_terminal"
+
+
+class TestITerm2ToGhosttyQuickTerminalHotkey:
+    """Tests for iTerm2 to Ghostty quick terminal hotkey conversion."""
+
+    def test_ghostty_export_quick_terminal_with_hotkey(self):
+        """Test Ghostty exports keybind for quick terminal hotkey from iTerm2."""
+        from console_cowboy.ctec.schema import (
+            QuickTerminalConfig,
+            QuickTerminalPosition,
+        )
+
+        # Simulate iTerm2's Ctrl+Shift+Cmd+X hotkey
+        ctec = CTEC(
+            quick_terminal=QuickTerminalConfig(
+                enabled=True,
+                position=QuickTerminalPosition.TOP,
+                hotkey_key_code=7,  # X key
+                hotkey_modifiers=1441792,  # Ctrl+Shift+Cmd
+            )
+        )
+        output = GhosttyAdapter.export(ctec)
+
+        # Should have the quick terminal position
+        assert "quick-terminal-position = top" in output
+        # Should have the keybind for toggle_quick_terminal
+        assert "keybind = global:ctrl+shift+super+x=toggle_quick_terminal" in output
+
+    def test_ghostty_export_quick_terminal_hotkey_grave(self):
+        """Test Ghostty exports Ctrl+` hotkey correctly."""
+        from console_cowboy.ctec.schema import QuickTerminalConfig
+        from console_cowboy.utils.keycodes import MACOS_MODIFIER_CONTROL
+
+        ctec = CTEC(
+            quick_terminal=QuickTerminalConfig(
+                enabled=True,
+                hotkey_key_code=50,  # Grave/backtick
+                hotkey_modifiers=MACOS_MODIFIER_CONTROL,
+            )
+        )
+        output = GhosttyAdapter.export(ctec)
+        assert "keybind = global:ctrl+grave=toggle_quick_terminal" in output
+
+    def test_ghostty_export_quick_terminal_warns_unknown_keycode(self):
+        """Test Ghostty warns when key code cannot be converted."""
+        from console_cowboy.ctec.schema import QuickTerminalConfig
+
+        ctec = CTEC(
+            quick_terminal=QuickTerminalConfig(
+                enabled=True,
+                hotkey_key_code=999,  # Unknown key code
+                hotkey_modifiers=0,
+            )
+        )
+        output = GhosttyAdapter.export(ctec)
+
+        # Should have a warning about the conversion failure
+        assert any("key code" in w.lower() for w in ctec.warnings)
+        # Should NOT have a keybind line (since conversion failed)
+        assert "keybind = " not in output
+
+    def test_iterm2_to_ghostty_roundtrip_preserves_hotkey(self):
+        """Test iTerm2 fixture with hotkey converts to Ghostty with keybind."""
+        # Load the iTerm2 fixture which has a Hotkey Window profile
+        from pathlib import Path
+
+        fixture_path = (
+            Path(__file__).parent / "fixtures/iterm2/com.googlecode.iterm2.plist"
+        )
+        ctec = ITerm2Adapter.parse(fixture_path)
+
+        # The fixture should have a quick_terminal with hotkey info
+        assert ctec.quick_terminal is not None
+        assert ctec.quick_terminal.enabled is True
+        assert ctec.quick_terminal.hotkey_key_code is not None
+
+        # Export to Ghostty
+        output = GhosttyAdapter.export(ctec)
+
+        # Should have a keybind for toggle_quick_terminal
+        assert "toggle_quick_terminal" in output
+        assert "keybind = global:" in output


### PR DESCRIPTION
## Summary

- Add macOS key code/modifier conversion utility for translating iTerm2's numeric hotkey format to Ghostty's string keybind format
- Update Ghostty adapter to generate `keybind = global:...=toggle_quick_terminal` when exporting quick terminal config with hotkey info
- Add comprehensive tests for key code conversion and iTerm2→Ghostty hotkey export

## Problem

When converting from iTerm2 to Ghostty, the quick terminal (hotkey window) configuration was missing the global keybinding. iTerm2 stores the hotkey as numeric values:
- `HotKey Key Code` (e.g., 7 for 'X')
- `HotKey Modifier Flags` (e.g., 1441792 for Ctrl+Shift+Cmd)

These were extracted but not converted to Ghostty's keybind format.

## Solution

Added a new utility module (`utils/keycodes.py`) that maps macOS virtual key codes and modifier flags to standard key names. The Ghostty adapter now generates the appropriate keybind line when exporting.

**Example conversion:**
- iTerm2: `^⇧⌘X` (HotKey Key Code=7, HotKey Modifier Flags=1441792)
- Ghostty: `keybind = global:ctrl+shift+super+x=toggle_quick_terminal`

## Test plan

- [x] All 198 existing tests pass
- [x] Added 17 new tests covering:
  - Key code to name conversion (letters, special keys, function keys)
  - Modifier flags to list conversion
  - Full hotkey to keybind conversion
  - Ghostty export with quick terminal hotkey
  - End-to-end iTerm2→Ghostty conversion

🤖 Generated with [Claude Code](https://claude.ai/code)